### PR TITLE
refactor: rename some types

### DIFF
--- a/book/en/options.md
+++ b/book/en/options.md
@@ -7,8 +7,8 @@ In addition to the values for the constructor of `g.E`, the following options av
 |-------------|----|-----------|-------------|
 |`width`|`number`|The width of this entity and the width of the scrolled area. Unline `g.E`, this is required.|N/A|
 |`height`|`number`|The height of this entity and the height of the scrolled area. Unline `g.E`, this is required.|N/A|
-|`vertical`|`boolean` or `ScrollbarLike`|Enable/disable vertical scrolling.  If a `ScrollbarLike` is given, used as the vertical scrollbar.|`false`|
-|`horizontal`|`boolean` or `ScrollbarLike`|Enable/disable horizontal scrolling.  If a `ScrollbarLike` is given, used as the horizontal scrollbar.|`false`|
+|`vertical`|`boolean` or `Scrollbar`|Enable/disable vertical scrolling.  If a `Scrollbar` is given, used as the vertical scrollbar.|`false`|
+|`horizontal`|`boolean` or `Scrollbar`|Enable/disable horizontal scrolling.  If a `Scrollbar` is given, used as the horizontal scrollbar.|`false`|
 |`touchScroll`|`boolean`|Enable/disable scrolling by dragging/swiping on the entity itself.|`false`|
 |`insertBars`|`boolean`|If `true`, scrollbars are shown inside the entity's rectangle.|`false`|
 

--- a/book/en/scrollbar.md
+++ b/book/en/scrollbar.md
@@ -1,10 +1,10 @@
 # Using Your Own Scrollbar
 
 As mentioned in [the previous chapter][opts], you can use your own scrollbars.
-By giving a `ScrollbarLike` instance to the `vertical` or `horizontal` property of the constructor argument,
+By giving a `Scrollbar` instance to the `vertical` or `horizontal` property of the constructor argument,
 it will be used as the scrollbar instead of the default one.
 
-For example, if you have `myScrollbar: ScrollbarLike`, it can be used as:
+For example, if you have `myScrollbar: Scrollbar`, it can be used as:
 
 ```
 const scrollable = new Scrollable({
@@ -17,9 +17,9 @@ const scrollable = new Scrollable({
 
 This makes `scrollable` verticall scrollable and its vertical scrollbar will be `myScrollbar`.
 
-### ScrollbarLike
+### Scrollbar
 
-`ScrollbarLike` is defined by TypeScript as the following:
+`Scrollbar` is defined by TypeScript as the following:
 
 ```
 interface ScrollbarOperations {
@@ -27,7 +27,7 @@ interface ScrollbarOperations {
 	setBarProperties(posRate?: number | null, contentLength?: number | null, viewLength?: number | null): void;
 }
 
-type ScrollbarLike = g.E & ScrollbarOperations;
+type Scrollbar = g.E & ScrollbarOperations;
 ```
 
 This means that scrollbars must be implemented as a subclass of `g.E` and have two properties:
@@ -50,7 +50,7 @@ any properties specified as `null` should not be changed.
 ### Default Scrollbars
 
 The default scrollbars, `NinePatchVerticalScrollbar` and `NinePatchHorizontalScrollbar` are
-the only `ScrollbarLike` implementations provided by akashic-scrollable.
+the only `Scrollbar` implementations provided by akashic-scrollable.
 As the names suggest, they use ninepatch images (`g.Surface`) to draw its bar and background.
 (If you are not familier with ninepatch, take a look at [a good introduction by libgdx][9patch].)
 

--- a/book/ja/options.md
+++ b/book/ja/options.md
@@ -7,8 +7,8 @@
 |-------------|----|-----------|-------------|
 |`width`|`number`|このエンティティの幅、そしてスクロール領域の幅。(`g.E` と異なりこの値は必須です)|N/A|
 |`height`|`number`|このエンティティの高さ、そしてスクロール領域の高さ。(`g.E` と異なりこの値は必須です)|N/A|
-|`vertical`|`boolean` or `ScrollbarLike`|縦スクロールの有効・無効。 `ScrollbarLike` が与えられた場合、縦スクロールバーとして使われます。|`false`|
-|`horizontal`|`boolean` or `ScrollbarLike`|横スクロールの有効・無効。 `ScrollbarLike` が与えられた場合、横スクロールバーとして使われます。|`false`|
+|`vertical`|`boolean` or `Scrollbar`|縦スクロールの有効・無効。 `Scrollbar` が与えられた場合、縦スクロールバーとして使われます。|`false`|
+|`horizontal`|`boolean` or `Scrollbar`|横スクロールの有効・無効。 `Scrollbar` が与えられた場合、横スクロールバーとして使われます。|`false`|
 |`touchScroll`|`boolean`|タッチスクロール(エンティティ全体のスワイプ操作によるスクロール)の有効・無効。|`false`|
 |`insertBars`|`boolean`|真の場合、スクロールバーをエンティティ矩形の内側に配置する。|`false`|
 

--- a/book/ja/scrollbar.md
+++ b/book/ja/scrollbar.md
@@ -1,10 +1,10 @@
 # カスタムスクロールバー
 
 [前節][opts] で述べた通り、スクロールバーのデザインは任意にカスタマイズできます。
-`Scrollable` のコンストラクタ引数の `vertical`, `horizontal` プロパティに `ScrollbarLike` のインスタンスを与えると、
+`Scrollable` のコンストラクタ引数の `vertical`, `horizontal` プロパティに `Scrollbar` のインスタンスを与えると、
 デフォルトのスクロールバーに代えてそのインスタンスが利用されます。
 
-たとえば `myScrollbar: ScrollbarLike` がある時、次のように利用することができます:
+たとえば `myScrollbar: Scrollbar` がある時、次のように利用することができます:
 
 ```
 const scrollable = new Scrollable({
@@ -17,9 +17,9 @@ const scrollable = new Scrollable({
 
 このコードは `scrollable` を縦方向にスクロール可能にし、そのスクロールバーとして `myScrollbar` を使います。
 
-### ScrollbarLike
+### Scrollbar
 
-`ScrollbarLike` は、TypeScriptで次のように定義されます:
+`Scrollbar` は、TypeScriptで次のように定義されます:
 
 ```
 interface ScrollbarOperations {
@@ -27,7 +27,7 @@ interface ScrollbarOperations {
 	setBarProperties(posRate?: number | null, contentLength?: number | null, viewLength?: number | null): void;
 }
 
-type ScrollbarLike = g.E & ScrollbarOperations;
+type Scrollbar = g.E & ScrollbarOperations;
 ```
 
 すなわちスクロールバーは `g.E` のサブクラスとして実装され、かつ二つのプロパティを持つ必要があります:
@@ -48,7 +48,7 @@ type ScrollbarLike = g.E & ScrollbarOperations;
 
 ### デフォルトのスクロールバー
 
-akashic-scrollable が提供する `ScrollbarLike` の実装クラスは二つ、
+akashic-scrollable が提供する `Scrollbar` の実装クラスは二つ、
 デフォルトのスクロールバーである `NinePatchVerticalScrollbar` と `NinePatchHorizontalScrollbar` です。
 これらは名前のとおり、与えられた画像 (`g.Surface`) を9パッチ画像としてバーや背景の描画に用いるものです。
 (9パッチについては [libgdxの文書のintroduction][9patch] などを参照してください。)

--- a/docs/apiref/classes/ninepatchhorizontalscrollbar.html
+++ b/docs/apiref/classes/ninepatchhorizontalscrollbar.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<title>DefaultHorizontalScrollbar | @xnv/akashic-scrollable</title>
+	<title>NinePatchHorizontalScrollbar | @xnv/akashic-scrollable</title>
 	<meta name="description" content="">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="stylesheet" href="../assets/css/main.css">
@@ -56,10 +56,10 @@
 					<a href="../globals.html">Globals</a>
 				</li>
 				<li>
-					<a href="defaulthorizontalscrollbar.html">DefaultHorizontalScrollbar</a>
+					<a href="ninepatchhorizontalscrollbar.html">NinePatchHorizontalScrollbar</a>
 				</li>
 			</ul>
-			<h1>Class DefaultHorizontalScrollbar</h1>
+			<h1>Class NinePatchHorizontalScrollbar</h1>
 		</div>
 	</div>
 </header>
@@ -69,10 +69,10 @@
 			<section class="tsd-panel tsd-comment">
 				<div class="tsd-comment tsd-typography">
 					<div class="lead">
-						<p>The default horizontal scrollbar entity.
-						Takes two images (as background and bar itself), use them in nine-patched style.</p>
+						<p>The ninepatch image scrollbar entity.
+						Takes two images as ninepatch images for the background and the bar itself.</p>
 					</div>
-					<p>デフォルトの横スクロールバー。
+					<p>9パッチ画像の横スクロールバー。
 					二つの画像(背景用・バー用)をとり、9パッチで拡大して利用する。</p>
 				</div>
 			</section>
@@ -83,7 +83,7 @@
 						<span class="tsd-signature-type">Pane</span>
 						<ul class="tsd-hierarchy">
 							<li>
-								<span class="target">DefaultHorizontalScrollbar</span>
+								<span class="target">NinePatchHorizontalScrollbar</span>
 							</li>
 						</ul>
 					</li>
@@ -105,100 +105,100 @@
 						<section class="tsd-index-section tsd-is-external">
 							<h3>Constructors</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-overwrite tsd-is-external"><a href="defaulthorizontalscrollbar.html#constructor" class="tsd-kind-icon">constructor</a></li>
+								<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-overwrite tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#constructor" class="tsd-kind-icon">constructor</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-external">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_bar" class="tsd-kind-icon">_bar</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_barimage" class="tsd-kind-icon">_bar<wbr>Image</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_bgrenderer" class="tsd-kind-icon">_bg<wbr>Renderer</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_bgsurface" class="tsd-kind-icon">_bg<wbr>Surface</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_cache" class="tsd-kind-icon">_cache</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_childrenarea" class="tsd-kind-icon">_children<wbr>Area</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_childrenrenderer" class="tsd-kind-icon">_children<wbr>Renderer</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_childrensurface" class="tsd-kind-icon">_children<wbr>Surface</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_contentlength" class="tsd-kind-icon">_content<wbr>Length</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_delta" class="tsd-kind-icon">_delta</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_deltaorigin" class="tsd-kind-icon">_delta<wbr>Origin</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_hastouchablechildren" class="tsd-kind-icon">_has<wbr>Touchable<wbr>Children</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_matrix" class="tsd-kind-icon">_matrix</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_normalizedpadding" class="tsd-kind-icon">_normalized<wbr>Padding</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_oldheight" class="tsd-kind-icon">_old<wbr>Height</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_oldwidth" class="tsd-kind-icon">_old<wbr>Width</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_padding" class="tsd-kind-icon">_padding</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_paddingchanged" class="tsd-kind-icon">_padding<wbr>Changed</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_renderedcamera" class="tsd-kind-icon">_rendered<wbr>Camera</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_renderer" class="tsd-kind-icon">_renderer</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_shouldrenderchildren" class="tsd-kind-icon">_should<wbr>Render<wbr>Children</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_targetcameras" class="tsd-kind-icon">_target<wbr>Cameras</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#angle" class="tsd-kind-icon">angle</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#backgroundeffector" class="tsd-kind-icon">background<wbr>Effector</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#backgroundimage" class="tsd-kind-icon">background<wbr>Image</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#children" class="tsd-kind-icon">children</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#compositeoperation" class="tsd-kind-icon">composite<wbr>Operation</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#height" class="tsd-kind-icon">height</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#id" class="tsd-kind-icon">id</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#local" class="tsd-kind-icon">local</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#message" class="tsd-kind-icon">message</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-external"><a href="defaulthorizontalscrollbar.html#onchangebarpositionrate" class="tsd-kind-icon">on<wbr>Change<wbr>Bar<wbr>Position<wbr>Rate</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#opacity" class="tsd-kind-icon">opacity</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#padding" class="tsd-kind-icon">padding</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#parent" class="tsd-kind-icon">parent</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#pointdown" class="tsd-kind-icon">point<wbr>Down</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#pointmove" class="tsd-kind-icon">point<wbr>Move</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#pointup" class="tsd-kind-icon">point<wbr>Up</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#scalex" class="tsd-kind-icon">scaleX</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#scaley" class="tsd-kind-icon">scaleY</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#scene" class="tsd-kind-icon">scene</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#state" class="tsd-kind-icon">state</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#tag" class="tsd-kind-icon">tag</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#targetcameras" class="tsd-kind-icon">target<wbr>Cameras</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#touchable" class="tsd-kind-icon">touchable</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#update" class="tsd-kind-icon">update</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#width" class="tsd-kind-icon">width</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#x" class="tsd-kind-icon">x</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#y" class="tsd-kind-icon">y</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_bar" class="tsd-kind-icon">_bar</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_barimage" class="tsd-kind-icon">_bar<wbr>Image</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_bgrenderer" class="tsd-kind-icon">_bg<wbr>Renderer</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_bgsurface" class="tsd-kind-icon">_bg<wbr>Surface</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_cache" class="tsd-kind-icon">_cache</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_childrenarea" class="tsd-kind-icon">_children<wbr>Area</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_childrenrenderer" class="tsd-kind-icon">_children<wbr>Renderer</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_childrensurface" class="tsd-kind-icon">_children<wbr>Surface</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_contentlength" class="tsd-kind-icon">_content<wbr>Length</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_delta" class="tsd-kind-icon">_delta</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_deltaorigin" class="tsd-kind-icon">_delta<wbr>Origin</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_hastouchablechildren" class="tsd-kind-icon">_has<wbr>Touchable<wbr>Children</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_matrix" class="tsd-kind-icon">_matrix</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_normalizedpadding" class="tsd-kind-icon">_normalized<wbr>Padding</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_oldheight" class="tsd-kind-icon">_old<wbr>Height</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_oldwidth" class="tsd-kind-icon">_old<wbr>Width</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_padding" class="tsd-kind-icon">_padding</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_paddingchanged" class="tsd-kind-icon">_padding<wbr>Changed</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_renderedcamera" class="tsd-kind-icon">_rendered<wbr>Camera</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_renderer" class="tsd-kind-icon">_renderer</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_shouldrenderchildren" class="tsd-kind-icon">_should<wbr>Render<wbr>Children</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_targetcameras" class="tsd-kind-icon">_target<wbr>Cameras</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#angle" class="tsd-kind-icon">angle</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#backgroundeffector" class="tsd-kind-icon">background<wbr>Effector</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#backgroundimage" class="tsd-kind-icon">background<wbr>Image</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#children" class="tsd-kind-icon">children</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#compositeoperation" class="tsd-kind-icon">composite<wbr>Operation</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#height" class="tsd-kind-icon">height</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#id" class="tsd-kind-icon">id</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#local" class="tsd-kind-icon">local</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#message" class="tsd-kind-icon">message</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#onchangebarpositionrate" class="tsd-kind-icon">on<wbr>Change<wbr>Bar<wbr>Position<wbr>Rate</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#opacity" class="tsd-kind-icon">opacity</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#padding" class="tsd-kind-icon">padding</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#parent" class="tsd-kind-icon">parent</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#pointdown" class="tsd-kind-icon">point<wbr>Down</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#pointmove" class="tsd-kind-icon">point<wbr>Move</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#pointup" class="tsd-kind-icon">point<wbr>Up</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#scalex" class="tsd-kind-icon">scaleX</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#scaley" class="tsd-kind-icon">scaleY</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#scene" class="tsd-kind-icon">scene</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#state" class="tsd-kind-icon">state</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#tag" class="tsd-kind-icon">tag</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#targetcameras" class="tsd-kind-icon">target<wbr>Cameras</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#touchable" class="tsd-kind-icon">touchable</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#update" class="tsd-kind-icon">update</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#width" class="tsd-kind-icon">width</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#x" class="tsd-kind-icon">x</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#y" class="tsd-kind-icon">y</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-external">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_calculateboundingrect" class="tsd-kind-icon">_calculate<wbr>Bounding<wbr>Rect</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_disabletouchpropagation" class="tsd-kind-icon">_disable<wbr>Touch<wbr>Propagation</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_enabletouchpropagation" class="tsd-kind-icon">_enable<wbr>Touch<wbr>Propagation</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_handlebarpointdown" class="tsd-kind-icon">_handle<wbr>Bar<wbr>Point<wbr>Down</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_handlebarpointmove" class="tsd-kind-icon">_handle<wbr>Bar<wbr>Point<wbr>Move</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_initialize" class="tsd-kind-icon">_initialize</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_istargetoperation" class="tsd-kind-icon">_is<wbr>Target<wbr>Operation</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_renderbackground" class="tsd-kind-icon">_render<wbr>Background</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_renderchildren" class="tsd-kind-icon">_render<wbr>Children</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaulthorizontalscrollbar.html#_updatematrix" class="tsd-kind-icon">_update<wbr>Matrix</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#append" class="tsd-kind-icon">append</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#calculateboundingrect" class="tsd-kind-icon">calculate<wbr>Bounding<wbr>Rect</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-external"><a href="defaulthorizontalscrollbar.html#destroy" class="tsd-kind-icon">destroy</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#destroyed" class="tsd-kind-icon">destroyed</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#findpointsourcebypoint" class="tsd-kind-icon">find<wbr>Point<wbr>Source<wbr>ByPoint</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#game" class="tsd-kind-icon">game</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#getmatrix" class="tsd-kind-icon">get<wbr>Matrix</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#hide" class="tsd-kind-icon">hide</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#insertbefore" class="tsd-kind-icon">insert<wbr>Before</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#invalidate" class="tsd-kind-icon">invalidate</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#modified" class="tsd-kind-icon">modified</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#moveby" class="tsd-kind-icon">move<wbr>By</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#moveto" class="tsd-kind-icon">move<wbr>To</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#remove" class="tsd-kind-icon">remove</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#render" class="tsd-kind-icon">render</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#rendercache" class="tsd-kind-icon">render<wbr>Cache</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#renderself" class="tsd-kind-icon">render<wbr>Self</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#resizeby" class="tsd-kind-icon">resize<wbr>By</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#resizeto" class="tsd-kind-icon">resize<wbr>To</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#scale" class="tsd-kind-icon">scale</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-external"><a href="defaulthorizontalscrollbar.html#setbarproperties" class="tsd-kind-icon">set<wbr>Bar<wbr>Properties</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#shouldfindchildrenbypoint" class="tsd-kind-icon">should<wbr>Find<wbr>Children<wbr>ByPoint</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#show" class="tsd-kind-icon">show</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaulthorizontalscrollbar.html#visible" class="tsd-kind-icon">visible</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_calculateboundingrect" class="tsd-kind-icon">_calculate<wbr>Bounding<wbr>Rect</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_disabletouchpropagation" class="tsd-kind-icon">_disable<wbr>Touch<wbr>Propagation</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_enabletouchpropagation" class="tsd-kind-icon">_enable<wbr>Touch<wbr>Propagation</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_handlebarpointdown" class="tsd-kind-icon">_handle<wbr>Bar<wbr>Point<wbr>Down</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_handlebarpointmove" class="tsd-kind-icon">_handle<wbr>Bar<wbr>Point<wbr>Move</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_initialize" class="tsd-kind-icon">_initialize</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_istargetoperation" class="tsd-kind-icon">_is<wbr>Target<wbr>Operation</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_renderbackground" class="tsd-kind-icon">_render<wbr>Background</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_renderchildren" class="tsd-kind-icon">_render<wbr>Children</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#_updatematrix" class="tsd-kind-icon">_update<wbr>Matrix</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#append" class="tsd-kind-icon">append</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#calculateboundingrect" class="tsd-kind-icon">calculate<wbr>Bounding<wbr>Rect</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#destroy" class="tsd-kind-icon">destroy</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#destroyed" class="tsd-kind-icon">destroyed</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#findpointsourcebypoint" class="tsd-kind-icon">find<wbr>Point<wbr>Source<wbr>ByPoint</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#game" class="tsd-kind-icon">game</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#getmatrix" class="tsd-kind-icon">get<wbr>Matrix</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#hide" class="tsd-kind-icon">hide</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#insertbefore" class="tsd-kind-icon">insert<wbr>Before</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#invalidate" class="tsd-kind-icon">invalidate</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#modified" class="tsd-kind-icon">modified</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#moveby" class="tsd-kind-icon">move<wbr>By</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#moveto" class="tsd-kind-icon">move<wbr>To</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#remove" class="tsd-kind-icon">remove</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#render" class="tsd-kind-icon">render</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#rendercache" class="tsd-kind-icon">render<wbr>Cache</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#renderself" class="tsd-kind-icon">render<wbr>Self</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#resizeby" class="tsd-kind-icon">resize<wbr>By</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#resizeto" class="tsd-kind-icon">resize<wbr>To</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#scale" class="tsd-kind-icon">scale</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#setbarproperties" class="tsd-kind-icon">set<wbr>Bar<wbr>Properties</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#shouldfindchildrenbypoint" class="tsd-kind-icon">should<wbr>Find<wbr>Children<wbr>ByPoint</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#show" class="tsd-kind-icon">show</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchhorizontalscrollbar.html#visible" class="tsd-kind-icon">visible</a></li>
 							</ul>
 						</section>
 					</div>
@@ -210,23 +210,23 @@
 					<a name="constructor" class="tsd-anchor"></a>
 					<h3>constructor</h3>
 					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class tsd-is-overwrite tsd-is-external">
-						<li class="tsd-signature tsd-kind-icon">new <wbr>Default<wbr>Horizontal<wbr>Scrollbar<span class="tsd-signature-symbol">(</span>param<span class="tsd-signature-symbol">: </span><a href="../interfaces/defaulthorizontalscrollbarparameterobject.html" class="tsd-signature-type">DefaultHorizontalScrollbarParameterObject</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="defaulthorizontalscrollbar.html" class="tsd-signature-type">DefaultHorizontalScrollbar</a></li>
+						<li class="tsd-signature tsd-kind-icon">new <wbr>Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar<span class="tsd-signature-symbol">(</span>param<span class="tsd-signature-symbol">: </span><a href="../interfaces/ninepatchhorizontalscrollbarparameterobject.html" class="tsd-signature-type">NinePatchHorizontalScrollbarParameterObject</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="ninepatchhorizontalscrollbar.html" class="tsd-signature-type">NinePatchHorizontalScrollbar</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<p>Overrides Pane.__constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultHorizontalScrollbar.ts#L28">DefaultHorizontalScrollbar.ts:28</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchHorizontalScrollbar.ts#L28">NinePatchHorizontalScrollbar.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>param: <a href="../interfaces/defaulthorizontalscrollbarparameterobject.html" class="tsd-signature-type">DefaultHorizontalScrollbarParameterObject</a></h5>
+									<h5>param: <a href="../interfaces/ninepatchhorizontalscrollbarparameterobject.html" class="tsd-signature-type">NinePatchHorizontalScrollbarParameterObject</a></h5>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <a href="defaulthorizontalscrollbar.html" class="tsd-signature-type">DefaultHorizontalScrollbar</a></h4>
+							<h4 class="tsd-returns-title">Returns <a href="ninepatchhorizontalscrollbar.html" class="tsd-signature-type">NinePatchHorizontalScrollbar</a></h4>
 						</li>
 					</ul>
 				</section>
@@ -239,7 +239,7 @@
 					<div class="tsd-signature tsd-kind-icon">_bar<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Pane</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultHorizontalScrollbar.ts#L24">DefaultHorizontalScrollbar.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchHorizontalScrollbar.ts#L24">NinePatchHorizontalScrollbar.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -249,7 +249,7 @@
 					<div class="tsd-signature tsd-kind-icon">_bar<wbr>Image<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Surface</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultHorizontalScrollbar.ts#L25">DefaultHorizontalScrollbar.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchHorizontalScrollbar.ts#L25">NinePatchHorizontalScrollbar.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -340,7 +340,7 @@
 					<div class="tsd-signature tsd-kind-icon">_content<wbr>Length<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultHorizontalScrollbar.ts#L26">DefaultHorizontalScrollbar.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchHorizontalScrollbar.ts#L26">NinePatchHorizontalScrollbar.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -350,7 +350,7 @@
 					<div class="tsd-signature tsd-kind-icon">_delta<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultHorizontalScrollbar.ts#L28">DefaultHorizontalScrollbar.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchHorizontalScrollbar.ts#L28">NinePatchHorizontalScrollbar.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -360,7 +360,7 @@
 					<div class="tsd-signature tsd-kind-icon">_delta<wbr>Origin<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultHorizontalScrollbar.ts#L27">DefaultHorizontalScrollbar.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchHorizontalScrollbar.ts#L27">NinePatchHorizontalScrollbar.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -695,7 +695,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/scrollbaroperations.html">ScrollbarOperations</a>.<a href="../interfaces/scrollbaroperations.html#onchangebarpositionrate">onChangeBarPositionRate</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultHorizontalScrollbar.ts#L23">DefaultHorizontalScrollbar.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchHorizontalScrollbar.ts#L23">NinePatchHorizontalScrollbar.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1079,7 +1079,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultHorizontalScrollbar.ts#L92">DefaultHorizontalScrollbar.ts:92</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchHorizontalScrollbar.ts#L92">NinePatchHorizontalScrollbar.ts:92</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1102,7 +1102,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultHorizontalScrollbar.ts#L97">DefaultHorizontalScrollbar.ts:97</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchHorizontalScrollbar.ts#L97">NinePatchHorizontalScrollbar.ts:97</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1305,7 +1305,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides Pane.destroy</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultHorizontalScrollbar.ts#L57">DefaultHorizontalScrollbar.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchHorizontalScrollbar.ts#L57">NinePatchHorizontalScrollbar.ts:57</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1953,7 +1953,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/scrollbaroperations.html">ScrollbarOperations</a>.<a href="../interfaces/scrollbaroperations.html#setbarproperties">setBarProperties</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultHorizontalScrollbar.ts#L66">DefaultHorizontalScrollbar.ts:66</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchHorizontalScrollbar.ts#L66">NinePatchHorizontalScrollbar.ts:66</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2060,266 +2060,266 @@
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-class tsd-is-external">
-						<a href="defaulthorizontalscrollbar.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar</a>
+						<a href="ninepatchhorizontalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar</a>
 						<ul>
 							<li class=" tsd-kind-constructor tsd-parent-kind-class tsd-is-overwrite tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#constructor" class="tsd-kind-icon">constructor</a>
+								<a href="ninepatchhorizontalscrollbar.html#constructor" class="tsd-kind-icon">constructor</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_bar" class="tsd-kind-icon">_bar</a>
+								<a href="ninepatchhorizontalscrollbar.html#_bar" class="tsd-kind-icon">_bar</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_barimage" class="tsd-kind-icon">_bar<wbr>Image</a>
+								<a href="ninepatchhorizontalscrollbar.html#_barimage" class="tsd-kind-icon">_bar<wbr>Image</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_bgrenderer" class="tsd-kind-icon">_bg<wbr>Renderer</a>
+								<a href="ninepatchhorizontalscrollbar.html#_bgrenderer" class="tsd-kind-icon">_bg<wbr>Renderer</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_bgsurface" class="tsd-kind-icon">_bg<wbr>Surface</a>
+								<a href="ninepatchhorizontalscrollbar.html#_bgsurface" class="tsd-kind-icon">_bg<wbr>Surface</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_cache" class="tsd-kind-icon">_cache</a>
+								<a href="ninepatchhorizontalscrollbar.html#_cache" class="tsd-kind-icon">_cache</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_childrenarea" class="tsd-kind-icon">_children<wbr>Area</a>
+								<a href="ninepatchhorizontalscrollbar.html#_childrenarea" class="tsd-kind-icon">_children<wbr>Area</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_childrenrenderer" class="tsd-kind-icon">_children<wbr>Renderer</a>
+								<a href="ninepatchhorizontalscrollbar.html#_childrenrenderer" class="tsd-kind-icon">_children<wbr>Renderer</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_childrensurface" class="tsd-kind-icon">_children<wbr>Surface</a>
+								<a href="ninepatchhorizontalscrollbar.html#_childrensurface" class="tsd-kind-icon">_children<wbr>Surface</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_contentlength" class="tsd-kind-icon">_content<wbr>Length</a>
+								<a href="ninepatchhorizontalscrollbar.html#_contentlength" class="tsd-kind-icon">_content<wbr>Length</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_delta" class="tsd-kind-icon">_delta</a>
+								<a href="ninepatchhorizontalscrollbar.html#_delta" class="tsd-kind-icon">_delta</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_deltaorigin" class="tsd-kind-icon">_delta<wbr>Origin</a>
+								<a href="ninepatchhorizontalscrollbar.html#_deltaorigin" class="tsd-kind-icon">_delta<wbr>Origin</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_hastouchablechildren" class="tsd-kind-icon">_has<wbr>Touchable<wbr>Children</a>
+								<a href="ninepatchhorizontalscrollbar.html#_hastouchablechildren" class="tsd-kind-icon">_has<wbr>Touchable<wbr>Children</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_matrix" class="tsd-kind-icon">_matrix</a>
+								<a href="ninepatchhorizontalscrollbar.html#_matrix" class="tsd-kind-icon">_matrix</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_normalizedpadding" class="tsd-kind-icon">_normalized<wbr>Padding</a>
+								<a href="ninepatchhorizontalscrollbar.html#_normalizedpadding" class="tsd-kind-icon">_normalized<wbr>Padding</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_oldheight" class="tsd-kind-icon">_old<wbr>Height</a>
+								<a href="ninepatchhorizontalscrollbar.html#_oldheight" class="tsd-kind-icon">_old<wbr>Height</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_oldwidth" class="tsd-kind-icon">_old<wbr>Width</a>
+								<a href="ninepatchhorizontalscrollbar.html#_oldwidth" class="tsd-kind-icon">_old<wbr>Width</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_padding" class="tsd-kind-icon">_padding</a>
+								<a href="ninepatchhorizontalscrollbar.html#_padding" class="tsd-kind-icon">_padding</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_paddingchanged" class="tsd-kind-icon">_padding<wbr>Changed</a>
+								<a href="ninepatchhorizontalscrollbar.html#_paddingchanged" class="tsd-kind-icon">_padding<wbr>Changed</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_renderedcamera" class="tsd-kind-icon">_rendered<wbr>Camera</a>
+								<a href="ninepatchhorizontalscrollbar.html#_renderedcamera" class="tsd-kind-icon">_rendered<wbr>Camera</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_renderer" class="tsd-kind-icon">_renderer</a>
+								<a href="ninepatchhorizontalscrollbar.html#_renderer" class="tsd-kind-icon">_renderer</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_shouldrenderchildren" class="tsd-kind-icon">_should<wbr>Render<wbr>Children</a>
+								<a href="ninepatchhorizontalscrollbar.html#_shouldrenderchildren" class="tsd-kind-icon">_should<wbr>Render<wbr>Children</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_targetcameras" class="tsd-kind-icon">_target<wbr>Cameras</a>
+								<a href="ninepatchhorizontalscrollbar.html#_targetcameras" class="tsd-kind-icon">_target<wbr>Cameras</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#angle" class="tsd-kind-icon">angle</a>
+								<a href="ninepatchhorizontalscrollbar.html#angle" class="tsd-kind-icon">angle</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#backgroundeffector" class="tsd-kind-icon">background<wbr>Effector</a>
+								<a href="ninepatchhorizontalscrollbar.html#backgroundeffector" class="tsd-kind-icon">background<wbr>Effector</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#backgroundimage" class="tsd-kind-icon">background<wbr>Image</a>
+								<a href="ninepatchhorizontalscrollbar.html#backgroundimage" class="tsd-kind-icon">background<wbr>Image</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#children" class="tsd-kind-icon">children</a>
+								<a href="ninepatchhorizontalscrollbar.html#children" class="tsd-kind-icon">children</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#compositeoperation" class="tsd-kind-icon">composite<wbr>Operation</a>
+								<a href="ninepatchhorizontalscrollbar.html#compositeoperation" class="tsd-kind-icon">composite<wbr>Operation</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#height" class="tsd-kind-icon">height</a>
+								<a href="ninepatchhorizontalscrollbar.html#height" class="tsd-kind-icon">height</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#id" class="tsd-kind-icon">id</a>
+								<a href="ninepatchhorizontalscrollbar.html#id" class="tsd-kind-icon">id</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#local" class="tsd-kind-icon">local</a>
+								<a href="ninepatchhorizontalscrollbar.html#local" class="tsd-kind-icon">local</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#message" class="tsd-kind-icon">message</a>
+								<a href="ninepatchhorizontalscrollbar.html#message" class="tsd-kind-icon">message</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#onchangebarpositionrate" class="tsd-kind-icon">on<wbr>Change<wbr>Bar<wbr>Position<wbr>Rate</a>
+								<a href="ninepatchhorizontalscrollbar.html#onchangebarpositionrate" class="tsd-kind-icon">on<wbr>Change<wbr>Bar<wbr>Position<wbr>Rate</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#opacity" class="tsd-kind-icon">opacity</a>
+								<a href="ninepatchhorizontalscrollbar.html#opacity" class="tsd-kind-icon">opacity</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#padding" class="tsd-kind-icon">padding</a>
+								<a href="ninepatchhorizontalscrollbar.html#padding" class="tsd-kind-icon">padding</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#parent" class="tsd-kind-icon">parent</a>
+								<a href="ninepatchhorizontalscrollbar.html#parent" class="tsd-kind-icon">parent</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#pointdown" class="tsd-kind-icon">point<wbr>Down</a>
+								<a href="ninepatchhorizontalscrollbar.html#pointdown" class="tsd-kind-icon">point<wbr>Down</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#pointmove" class="tsd-kind-icon">point<wbr>Move</a>
+								<a href="ninepatchhorizontalscrollbar.html#pointmove" class="tsd-kind-icon">point<wbr>Move</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#pointup" class="tsd-kind-icon">point<wbr>Up</a>
+								<a href="ninepatchhorizontalscrollbar.html#pointup" class="tsd-kind-icon">point<wbr>Up</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#scalex" class="tsd-kind-icon">scaleX</a>
+								<a href="ninepatchhorizontalscrollbar.html#scalex" class="tsd-kind-icon">scaleX</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#scaley" class="tsd-kind-icon">scaleY</a>
+								<a href="ninepatchhorizontalscrollbar.html#scaley" class="tsd-kind-icon">scaleY</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#scene" class="tsd-kind-icon">scene</a>
+								<a href="ninepatchhorizontalscrollbar.html#scene" class="tsd-kind-icon">scene</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#state" class="tsd-kind-icon">state</a>
+								<a href="ninepatchhorizontalscrollbar.html#state" class="tsd-kind-icon">state</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#tag" class="tsd-kind-icon">tag</a>
+								<a href="ninepatchhorizontalscrollbar.html#tag" class="tsd-kind-icon">tag</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#targetcameras" class="tsd-kind-icon">target<wbr>Cameras</a>
+								<a href="ninepatchhorizontalscrollbar.html#targetcameras" class="tsd-kind-icon">target<wbr>Cameras</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#touchable" class="tsd-kind-icon">touchable</a>
+								<a href="ninepatchhorizontalscrollbar.html#touchable" class="tsd-kind-icon">touchable</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#update" class="tsd-kind-icon">update</a>
+								<a href="ninepatchhorizontalscrollbar.html#update" class="tsd-kind-icon">update</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#width" class="tsd-kind-icon">width</a>
+								<a href="ninepatchhorizontalscrollbar.html#width" class="tsd-kind-icon">width</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#x" class="tsd-kind-icon">x</a>
+								<a href="ninepatchhorizontalscrollbar.html#x" class="tsd-kind-icon">x</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#y" class="tsd-kind-icon">y</a>
+								<a href="ninepatchhorizontalscrollbar.html#y" class="tsd-kind-icon">y</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_calculateboundingrect" class="tsd-kind-icon">_calculate<wbr>Bounding<wbr>Rect</a>
+								<a href="ninepatchhorizontalscrollbar.html#_calculateboundingrect" class="tsd-kind-icon">_calculate<wbr>Bounding<wbr>Rect</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_disabletouchpropagation" class="tsd-kind-icon">_disable<wbr>Touch<wbr>Propagation</a>
+								<a href="ninepatchhorizontalscrollbar.html#_disabletouchpropagation" class="tsd-kind-icon">_disable<wbr>Touch<wbr>Propagation</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_enabletouchpropagation" class="tsd-kind-icon">_enable<wbr>Touch<wbr>Propagation</a>
+								<a href="ninepatchhorizontalscrollbar.html#_enabletouchpropagation" class="tsd-kind-icon">_enable<wbr>Touch<wbr>Propagation</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_handlebarpointdown" class="tsd-kind-icon">_handle<wbr>Bar<wbr>Point<wbr>Down</a>
+								<a href="ninepatchhorizontalscrollbar.html#_handlebarpointdown" class="tsd-kind-icon">_handle<wbr>Bar<wbr>Point<wbr>Down</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_handlebarpointmove" class="tsd-kind-icon">_handle<wbr>Bar<wbr>Point<wbr>Move</a>
+								<a href="ninepatchhorizontalscrollbar.html#_handlebarpointmove" class="tsd-kind-icon">_handle<wbr>Bar<wbr>Point<wbr>Move</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_initialize" class="tsd-kind-icon">_initialize</a>
+								<a href="ninepatchhorizontalscrollbar.html#_initialize" class="tsd-kind-icon">_initialize</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_istargetoperation" class="tsd-kind-icon">_is<wbr>Target<wbr>Operation</a>
+								<a href="ninepatchhorizontalscrollbar.html#_istargetoperation" class="tsd-kind-icon">_is<wbr>Target<wbr>Operation</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_renderbackground" class="tsd-kind-icon">_render<wbr>Background</a>
+								<a href="ninepatchhorizontalscrollbar.html#_renderbackground" class="tsd-kind-icon">_render<wbr>Background</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_renderchildren" class="tsd-kind-icon">_render<wbr>Children</a>
+								<a href="ninepatchhorizontalscrollbar.html#_renderchildren" class="tsd-kind-icon">_render<wbr>Children</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#_updatematrix" class="tsd-kind-icon">_update<wbr>Matrix</a>
+								<a href="ninepatchhorizontalscrollbar.html#_updatematrix" class="tsd-kind-icon">_update<wbr>Matrix</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#append" class="tsd-kind-icon">append</a>
+								<a href="ninepatchhorizontalscrollbar.html#append" class="tsd-kind-icon">append</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#calculateboundingrect" class="tsd-kind-icon">calculate<wbr>Bounding<wbr>Rect</a>
+								<a href="ninepatchhorizontalscrollbar.html#calculateboundingrect" class="tsd-kind-icon">calculate<wbr>Bounding<wbr>Rect</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#destroy" class="tsd-kind-icon">destroy</a>
+								<a href="ninepatchhorizontalscrollbar.html#destroy" class="tsd-kind-icon">destroy</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#destroyed" class="tsd-kind-icon">destroyed</a>
+								<a href="ninepatchhorizontalscrollbar.html#destroyed" class="tsd-kind-icon">destroyed</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#findpointsourcebypoint" class="tsd-kind-icon">find<wbr>Point<wbr>Source<wbr>ByPoint</a>
+								<a href="ninepatchhorizontalscrollbar.html#findpointsourcebypoint" class="tsd-kind-icon">find<wbr>Point<wbr>Source<wbr>ByPoint</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#game" class="tsd-kind-icon">game</a>
+								<a href="ninepatchhorizontalscrollbar.html#game" class="tsd-kind-icon">game</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#getmatrix" class="tsd-kind-icon">get<wbr>Matrix</a>
+								<a href="ninepatchhorizontalscrollbar.html#getmatrix" class="tsd-kind-icon">get<wbr>Matrix</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#hide" class="tsd-kind-icon">hide</a>
+								<a href="ninepatchhorizontalscrollbar.html#hide" class="tsd-kind-icon">hide</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#insertbefore" class="tsd-kind-icon">insert<wbr>Before</a>
+								<a href="ninepatchhorizontalscrollbar.html#insertbefore" class="tsd-kind-icon">insert<wbr>Before</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#invalidate" class="tsd-kind-icon">invalidate</a>
+								<a href="ninepatchhorizontalscrollbar.html#invalidate" class="tsd-kind-icon">invalidate</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#modified" class="tsd-kind-icon">modified</a>
+								<a href="ninepatchhorizontalscrollbar.html#modified" class="tsd-kind-icon">modified</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#moveby" class="tsd-kind-icon">move<wbr>By</a>
+								<a href="ninepatchhorizontalscrollbar.html#moveby" class="tsd-kind-icon">move<wbr>By</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#moveto" class="tsd-kind-icon">move<wbr>To</a>
+								<a href="ninepatchhorizontalscrollbar.html#moveto" class="tsd-kind-icon">move<wbr>To</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#remove" class="tsd-kind-icon">remove</a>
+								<a href="ninepatchhorizontalscrollbar.html#remove" class="tsd-kind-icon">remove</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#render" class="tsd-kind-icon">render</a>
+								<a href="ninepatchhorizontalscrollbar.html#render" class="tsd-kind-icon">render</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#rendercache" class="tsd-kind-icon">render<wbr>Cache</a>
+								<a href="ninepatchhorizontalscrollbar.html#rendercache" class="tsd-kind-icon">render<wbr>Cache</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#renderself" class="tsd-kind-icon">render<wbr>Self</a>
+								<a href="ninepatchhorizontalscrollbar.html#renderself" class="tsd-kind-icon">render<wbr>Self</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#resizeby" class="tsd-kind-icon">resize<wbr>By</a>
+								<a href="ninepatchhorizontalscrollbar.html#resizeby" class="tsd-kind-icon">resize<wbr>By</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#resizeto" class="tsd-kind-icon">resize<wbr>To</a>
+								<a href="ninepatchhorizontalscrollbar.html#resizeto" class="tsd-kind-icon">resize<wbr>To</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#scale" class="tsd-kind-icon">scale</a>
+								<a href="ninepatchhorizontalscrollbar.html#scale" class="tsd-kind-icon">scale</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#setbarproperties" class="tsd-kind-icon">set<wbr>Bar<wbr>Properties</a>
+								<a href="ninepatchhorizontalscrollbar.html#setbarproperties" class="tsd-kind-icon">set<wbr>Bar<wbr>Properties</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#shouldfindchildrenbypoint" class="tsd-kind-icon">should<wbr>Find<wbr>Children<wbr>ByPoint</a>
+								<a href="ninepatchhorizontalscrollbar.html#shouldfindchildrenbypoint" class="tsd-kind-icon">should<wbr>Find<wbr>Children<wbr>ByPoint</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#show" class="tsd-kind-icon">show</a>
+								<a href="ninepatchhorizontalscrollbar.html#show" class="tsd-kind-icon">show</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaulthorizontalscrollbar.html#visible" class="tsd-kind-icon">visible</a>
+								<a href="ninepatchhorizontalscrollbar.html#visible" class="tsd-kind-icon">visible</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-class tsd-is-external">
-						<a href="defaultverticalscrollbar.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar</a>
+						<a href="ninepatchverticalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-class tsd-is-external">
 						<a href="nullscrollbar.html" class="tsd-kind-icon">Null<wbr>Scrollbar</a>
@@ -2334,10 +2334,10 @@
 						<a href="scrolledcontentcontainer.html" class="tsd-kind-icon">Scrolled<wbr>Content<wbr>Container</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
-						<a href="../interfaces/defaulthorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="../interfaces/ninepatchhorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
-						<a href="../interfaces/defaultverticalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="../interfaces/ninepatchverticalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
 						<a href="../interfaces/scrollableparameterobject.html" class="tsd-kind-icon">Scrollable<wbr>Parameter<wbr>Object</a>
@@ -2346,7 +2346,7 @@
 						<a href="../interfaces/scrollbaroperations.html" class="tsd-kind-icon">Scrollbar<wbr>Operations</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-is-external">
-						<a href="../globals.html#scrollbarlike" class="tsd-kind-icon">Scrollbar<wbr>Like</a>
+						<a href="../globals.html#scrollbar" class="tsd-kind-icon">Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-function tsd-is-external">
 						<a href="../globals.html#createdefaultscrollbarimage" class="tsd-kind-icon">create<wbr>Default<wbr>Scrollbar<wbr>Image</a>

--- a/docs/apiref/classes/ninepatchverticalscrollbar.html
+++ b/docs/apiref/classes/ninepatchverticalscrollbar.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<title>DefaultVerticalScrollbar | @xnv/akashic-scrollable</title>
+	<title>NinePatchVerticalScrollbar | @xnv/akashic-scrollable</title>
 	<meta name="description" content="">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="stylesheet" href="../assets/css/main.css">
@@ -56,10 +56,10 @@
 					<a href="../globals.html">Globals</a>
 				</li>
 				<li>
-					<a href="defaultverticalscrollbar.html">DefaultVerticalScrollbar</a>
+					<a href="ninepatchverticalscrollbar.html">NinePatchVerticalScrollbar</a>
 				</li>
 			</ul>
-			<h1>Class DefaultVerticalScrollbar</h1>
+			<h1>Class NinePatchVerticalScrollbar</h1>
 		</div>
 	</div>
 </header>
@@ -69,10 +69,10 @@
 			<section class="tsd-panel tsd-comment">
 				<div class="tsd-comment tsd-typography">
 					<div class="lead">
-						<p>The default vertical scrollbar entity.
-						Takes two images (as background and bar itself), use them in nine-patched style.</p>
+						<p>The ninepatch image vertical scrollbar entity.
+						Takes two images as ninepatch images for the background and the bar itself.</p>
 					</div>
-					<p>デフォルトの縦スクロールバー。
+					<p>9パッチ画像の縦スクロールバー。
 					二つの画像(背景用・バー用)をとり、9パッチで拡大して利用する。</p>
 				</div>
 			</section>
@@ -83,7 +83,7 @@
 						<span class="tsd-signature-type">Pane</span>
 						<ul class="tsd-hierarchy">
 							<li>
-								<span class="target">DefaultVerticalScrollbar</span>
+								<span class="target">NinePatchVerticalScrollbar</span>
 							</li>
 						</ul>
 					</li>
@@ -105,100 +105,100 @@
 						<section class="tsd-index-section tsd-is-external">
 							<h3>Constructors</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-overwrite tsd-is-external"><a href="defaultverticalscrollbar.html#constructor" class="tsd-kind-icon">constructor</a></li>
+								<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-overwrite tsd-is-external"><a href="ninepatchverticalscrollbar.html#constructor" class="tsd-kind-icon">constructor</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-external">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_bar" class="tsd-kind-icon">_bar</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_barimage" class="tsd-kind-icon">_bar<wbr>Image</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_bgrenderer" class="tsd-kind-icon">_bg<wbr>Renderer</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_bgsurface" class="tsd-kind-icon">_bg<wbr>Surface</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_cache" class="tsd-kind-icon">_cache</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_childrenarea" class="tsd-kind-icon">_children<wbr>Area</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_childrenrenderer" class="tsd-kind-icon">_children<wbr>Renderer</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_childrensurface" class="tsd-kind-icon">_children<wbr>Surface</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_contentlength" class="tsd-kind-icon">_content<wbr>Length</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_delta" class="tsd-kind-icon">_delta</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_deltaorigin" class="tsd-kind-icon">_delta<wbr>Origin</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_hastouchablechildren" class="tsd-kind-icon">_has<wbr>Touchable<wbr>Children</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_matrix" class="tsd-kind-icon">_matrix</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_normalizedpadding" class="tsd-kind-icon">_normalized<wbr>Padding</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_oldheight" class="tsd-kind-icon">_old<wbr>Height</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_oldwidth" class="tsd-kind-icon">_old<wbr>Width</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_padding" class="tsd-kind-icon">_padding</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_paddingchanged" class="tsd-kind-icon">_padding<wbr>Changed</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_renderedcamera" class="tsd-kind-icon">_rendered<wbr>Camera</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_renderer" class="tsd-kind-icon">_renderer</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_shouldrenderchildren" class="tsd-kind-icon">_should<wbr>Render<wbr>Children</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_targetcameras" class="tsd-kind-icon">_target<wbr>Cameras</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#angle" class="tsd-kind-icon">angle</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#backgroundeffector" class="tsd-kind-icon">background<wbr>Effector</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#backgroundimage" class="tsd-kind-icon">background<wbr>Image</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#children" class="tsd-kind-icon">children</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#compositeoperation" class="tsd-kind-icon">composite<wbr>Operation</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#height" class="tsd-kind-icon">height</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#id" class="tsd-kind-icon">id</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#local" class="tsd-kind-icon">local</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#message" class="tsd-kind-icon">message</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-external"><a href="defaultverticalscrollbar.html#onchangebarpositionrate" class="tsd-kind-icon">on<wbr>Change<wbr>Bar<wbr>Position<wbr>Rate</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#opacity" class="tsd-kind-icon">opacity</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#padding" class="tsd-kind-icon">padding</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#parent" class="tsd-kind-icon">parent</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#pointdown" class="tsd-kind-icon">point<wbr>Down</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#pointmove" class="tsd-kind-icon">point<wbr>Move</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#pointup" class="tsd-kind-icon">point<wbr>Up</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#scalex" class="tsd-kind-icon">scaleX</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#scaley" class="tsd-kind-icon">scaleY</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#scene" class="tsd-kind-icon">scene</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#state" class="tsd-kind-icon">state</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#tag" class="tsd-kind-icon">tag</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#targetcameras" class="tsd-kind-icon">target<wbr>Cameras</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#touchable" class="tsd-kind-icon">touchable</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#update" class="tsd-kind-icon">update</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#width" class="tsd-kind-icon">width</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#x" class="tsd-kind-icon">x</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#y" class="tsd-kind-icon">y</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_bar" class="tsd-kind-icon">_bar</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_barimage" class="tsd-kind-icon">_bar<wbr>Image</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_bgrenderer" class="tsd-kind-icon">_bg<wbr>Renderer</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_bgsurface" class="tsd-kind-icon">_bg<wbr>Surface</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_cache" class="tsd-kind-icon">_cache</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_childrenarea" class="tsd-kind-icon">_children<wbr>Area</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_childrenrenderer" class="tsd-kind-icon">_children<wbr>Renderer</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_childrensurface" class="tsd-kind-icon">_children<wbr>Surface</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_contentlength" class="tsd-kind-icon">_content<wbr>Length</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_delta" class="tsd-kind-icon">_delta</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_deltaorigin" class="tsd-kind-icon">_delta<wbr>Origin</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_hastouchablechildren" class="tsd-kind-icon">_has<wbr>Touchable<wbr>Children</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_matrix" class="tsd-kind-icon">_matrix</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_normalizedpadding" class="tsd-kind-icon">_normalized<wbr>Padding</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_oldheight" class="tsd-kind-icon">_old<wbr>Height</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_oldwidth" class="tsd-kind-icon">_old<wbr>Width</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_padding" class="tsd-kind-icon">_padding</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_paddingchanged" class="tsd-kind-icon">_padding<wbr>Changed</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_renderedcamera" class="tsd-kind-icon">_rendered<wbr>Camera</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_renderer" class="tsd-kind-icon">_renderer</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_shouldrenderchildren" class="tsd-kind-icon">_should<wbr>Render<wbr>Children</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_targetcameras" class="tsd-kind-icon">_target<wbr>Cameras</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#angle" class="tsd-kind-icon">angle</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#backgroundeffector" class="tsd-kind-icon">background<wbr>Effector</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#backgroundimage" class="tsd-kind-icon">background<wbr>Image</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#children" class="tsd-kind-icon">children</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#compositeoperation" class="tsd-kind-icon">composite<wbr>Operation</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#height" class="tsd-kind-icon">height</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#id" class="tsd-kind-icon">id</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#local" class="tsd-kind-icon">local</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#message" class="tsd-kind-icon">message</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-external"><a href="ninepatchverticalscrollbar.html#onchangebarpositionrate" class="tsd-kind-icon">on<wbr>Change<wbr>Bar<wbr>Position<wbr>Rate</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#opacity" class="tsd-kind-icon">opacity</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#padding" class="tsd-kind-icon">padding</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#parent" class="tsd-kind-icon">parent</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#pointdown" class="tsd-kind-icon">point<wbr>Down</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#pointmove" class="tsd-kind-icon">point<wbr>Move</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#pointup" class="tsd-kind-icon">point<wbr>Up</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#scalex" class="tsd-kind-icon">scaleX</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#scaley" class="tsd-kind-icon">scaleY</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#scene" class="tsd-kind-icon">scene</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#state" class="tsd-kind-icon">state</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#tag" class="tsd-kind-icon">tag</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#targetcameras" class="tsd-kind-icon">target<wbr>Cameras</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#touchable" class="tsd-kind-icon">touchable</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#update" class="tsd-kind-icon">update</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#width" class="tsd-kind-icon">width</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#x" class="tsd-kind-icon">x</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#y" class="tsd-kind-icon">y</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-external">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_calculateboundingrect" class="tsd-kind-icon">_calculate<wbr>Bounding<wbr>Rect</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_disabletouchpropagation" class="tsd-kind-icon">_disable<wbr>Touch<wbr>Propagation</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_enabletouchpropagation" class="tsd-kind-icon">_enable<wbr>Touch<wbr>Propagation</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_handlebarpointdown" class="tsd-kind-icon">_handle<wbr>Bar<wbr>Point<wbr>Down</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_handlebarpointmove" class="tsd-kind-icon">_handle<wbr>Bar<wbr>Point<wbr>Move</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_initialize" class="tsd-kind-icon">_initialize</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_istargetoperation" class="tsd-kind-icon">_is<wbr>Target<wbr>Operation</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_renderbackground" class="tsd-kind-icon">_render<wbr>Background</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_renderchildren" class="tsd-kind-icon">_render<wbr>Children</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="defaultverticalscrollbar.html#_updatematrix" class="tsd-kind-icon">_update<wbr>Matrix</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#append" class="tsd-kind-icon">append</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#calculateboundingrect" class="tsd-kind-icon">calculate<wbr>Bounding<wbr>Rect</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-external"><a href="defaultverticalscrollbar.html#destroy" class="tsd-kind-icon">destroy</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#destroyed" class="tsd-kind-icon">destroyed</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#findpointsourcebypoint" class="tsd-kind-icon">find<wbr>Point<wbr>Source<wbr>ByPoint</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#game" class="tsd-kind-icon">game</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#getmatrix" class="tsd-kind-icon">get<wbr>Matrix</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#hide" class="tsd-kind-icon">hide</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#insertbefore" class="tsd-kind-icon">insert<wbr>Before</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#invalidate" class="tsd-kind-icon">invalidate</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#modified" class="tsd-kind-icon">modified</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#moveby" class="tsd-kind-icon">move<wbr>By</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#moveto" class="tsd-kind-icon">move<wbr>To</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#remove" class="tsd-kind-icon">remove</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#render" class="tsd-kind-icon">render</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#rendercache" class="tsd-kind-icon">render<wbr>Cache</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#renderself" class="tsd-kind-icon">render<wbr>Self</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#resizeby" class="tsd-kind-icon">resize<wbr>By</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#resizeto" class="tsd-kind-icon">resize<wbr>To</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#scale" class="tsd-kind-icon">scale</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-external"><a href="defaultverticalscrollbar.html#setbarproperties" class="tsd-kind-icon">set<wbr>Bar<wbr>Properties</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#shouldfindchildrenbypoint" class="tsd-kind-icon">should<wbr>Find<wbr>Children<wbr>ByPoint</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#show" class="tsd-kind-icon">show</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="defaultverticalscrollbar.html#visible" class="tsd-kind-icon">visible</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_calculateboundingrect" class="tsd-kind-icon">_calculate<wbr>Bounding<wbr>Rect</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_disabletouchpropagation" class="tsd-kind-icon">_disable<wbr>Touch<wbr>Propagation</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_enabletouchpropagation" class="tsd-kind-icon">_enable<wbr>Touch<wbr>Propagation</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_handlebarpointdown" class="tsd-kind-icon">_handle<wbr>Bar<wbr>Point<wbr>Down</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_handlebarpointmove" class="tsd-kind-icon">_handle<wbr>Bar<wbr>Point<wbr>Move</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_initialize" class="tsd-kind-icon">_initialize</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_istargetoperation" class="tsd-kind-icon">_is<wbr>Target<wbr>Operation</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_renderbackground" class="tsd-kind-icon">_render<wbr>Background</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_renderchildren" class="tsd-kind-icon">_render<wbr>Children</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external"><a href="ninepatchverticalscrollbar.html#_updatematrix" class="tsd-kind-icon">_update<wbr>Matrix</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#append" class="tsd-kind-icon">append</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#calculateboundingrect" class="tsd-kind-icon">calculate<wbr>Bounding<wbr>Rect</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-external"><a href="ninepatchverticalscrollbar.html#destroy" class="tsd-kind-icon">destroy</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#destroyed" class="tsd-kind-icon">destroyed</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#findpointsourcebypoint" class="tsd-kind-icon">find<wbr>Point<wbr>Source<wbr>ByPoint</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#game" class="tsd-kind-icon">game</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#getmatrix" class="tsd-kind-icon">get<wbr>Matrix</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#hide" class="tsd-kind-icon">hide</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#insertbefore" class="tsd-kind-icon">insert<wbr>Before</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#invalidate" class="tsd-kind-icon">invalidate</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#modified" class="tsd-kind-icon">modified</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#moveby" class="tsd-kind-icon">move<wbr>By</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#moveto" class="tsd-kind-icon">move<wbr>To</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#remove" class="tsd-kind-icon">remove</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#render" class="tsd-kind-icon">render</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#rendercache" class="tsd-kind-icon">render<wbr>Cache</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#renderself" class="tsd-kind-icon">render<wbr>Self</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#resizeby" class="tsd-kind-icon">resize<wbr>By</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#resizeto" class="tsd-kind-icon">resize<wbr>To</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#scale" class="tsd-kind-icon">scale</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-external"><a href="ninepatchverticalscrollbar.html#setbarproperties" class="tsd-kind-icon">set<wbr>Bar<wbr>Properties</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#shouldfindchildrenbypoint" class="tsd-kind-icon">should<wbr>Find<wbr>Children<wbr>ByPoint</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#show" class="tsd-kind-icon">show</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external"><a href="ninepatchverticalscrollbar.html#visible" class="tsd-kind-icon">visible</a></li>
 							</ul>
 						</section>
 					</div>
@@ -210,23 +210,23 @@
 					<a name="constructor" class="tsd-anchor"></a>
 					<h3>constructor</h3>
 					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class tsd-is-overwrite tsd-is-external">
-						<li class="tsd-signature tsd-kind-icon">new <wbr>Default<wbr>Vertical<wbr>Scrollbar<span class="tsd-signature-symbol">(</span>param<span class="tsd-signature-symbol">: </span><a href="../interfaces/defaultverticalscrollbarparameterobject.html" class="tsd-signature-type">DefaultVerticalScrollbarParameterObject</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="defaultverticalscrollbar.html" class="tsd-signature-type">DefaultVerticalScrollbar</a></li>
+						<li class="tsd-signature tsd-kind-icon">new <wbr>Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar<span class="tsd-signature-symbol">(</span>param<span class="tsd-signature-symbol">: </span><a href="../interfaces/ninepatchverticalscrollbarparameterobject.html" class="tsd-signature-type">NinePatchVerticalScrollbarParameterObject</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="ninepatchverticalscrollbar.html" class="tsd-signature-type">NinePatchVerticalScrollbar</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<p>Overrides Pane.__constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultVerticalScrollbar.ts#L27">DefaultVerticalScrollbar.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchVerticalScrollbar.ts#L27">NinePatchVerticalScrollbar.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>param: <a href="../interfaces/defaultverticalscrollbarparameterobject.html" class="tsd-signature-type">DefaultVerticalScrollbarParameterObject</a></h5>
+									<h5>param: <a href="../interfaces/ninepatchverticalscrollbarparameterobject.html" class="tsd-signature-type">NinePatchVerticalScrollbarParameterObject</a></h5>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <a href="defaultverticalscrollbar.html" class="tsd-signature-type">DefaultVerticalScrollbar</a></h4>
+							<h4 class="tsd-returns-title">Returns <a href="ninepatchverticalscrollbar.html" class="tsd-signature-type">NinePatchVerticalScrollbar</a></h4>
 						</li>
 					</ul>
 				</section>
@@ -239,7 +239,7 @@
 					<div class="tsd-signature tsd-kind-icon">_bar<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Pane</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultVerticalScrollbar.ts#L23">DefaultVerticalScrollbar.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchVerticalScrollbar.ts#L23">NinePatchVerticalScrollbar.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -249,7 +249,7 @@
 					<div class="tsd-signature tsd-kind-icon">_bar<wbr>Image<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Surface</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultVerticalScrollbar.ts#L24">DefaultVerticalScrollbar.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchVerticalScrollbar.ts#L24">NinePatchVerticalScrollbar.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -340,7 +340,7 @@
 					<div class="tsd-signature tsd-kind-icon">_content<wbr>Length<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultVerticalScrollbar.ts#L25">DefaultVerticalScrollbar.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchVerticalScrollbar.ts#L25">NinePatchVerticalScrollbar.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -350,7 +350,7 @@
 					<div class="tsd-signature tsd-kind-icon">_delta<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultVerticalScrollbar.ts#L27">DefaultVerticalScrollbar.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchVerticalScrollbar.ts#L27">NinePatchVerticalScrollbar.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -360,7 +360,7 @@
 					<div class="tsd-signature tsd-kind-icon">_delta<wbr>Origin<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultVerticalScrollbar.ts#L26">DefaultVerticalScrollbar.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchVerticalScrollbar.ts#L26">NinePatchVerticalScrollbar.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -695,7 +695,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/scrollbaroperations.html">ScrollbarOperations</a>.<a href="../interfaces/scrollbaroperations.html#onchangebarpositionrate">onChangeBarPositionRate</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultVerticalScrollbar.ts#L22">DefaultVerticalScrollbar.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchVerticalScrollbar.ts#L22">NinePatchVerticalScrollbar.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1079,7 +1079,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultVerticalScrollbar.ts#L91">DefaultVerticalScrollbar.ts:91</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchVerticalScrollbar.ts#L91">NinePatchVerticalScrollbar.ts:91</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1102,7 +1102,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultVerticalScrollbar.ts#L96">DefaultVerticalScrollbar.ts:96</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchVerticalScrollbar.ts#L96">NinePatchVerticalScrollbar.ts:96</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1305,7 +1305,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides Pane.destroy</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultVerticalScrollbar.ts#L56">DefaultVerticalScrollbar.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchVerticalScrollbar.ts#L56">NinePatchVerticalScrollbar.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1953,7 +1953,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/scrollbaroperations.html">ScrollbarOperations</a>.<a href="../interfaces/scrollbaroperations.html#setbarproperties">setBarProperties</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultVerticalScrollbar.ts#L65">DefaultVerticalScrollbar.ts:65</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchVerticalScrollbar.ts#L65">NinePatchVerticalScrollbar.ts:65</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2058,264 +2058,264 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-is-external">
-						<a href="defaulthorizontalscrollbar.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar</a>
+						<a href="ninepatchhorizontalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar</a>
 					</li>
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-class tsd-is-external">
-						<a href="defaultverticalscrollbar.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar</a>
+						<a href="ninepatchverticalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar</a>
 						<ul>
 							<li class=" tsd-kind-constructor tsd-parent-kind-class tsd-is-overwrite tsd-is-external">
-								<a href="defaultverticalscrollbar.html#constructor" class="tsd-kind-icon">constructor</a>
+								<a href="ninepatchverticalscrollbar.html#constructor" class="tsd-kind-icon">constructor</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_bar" class="tsd-kind-icon">_bar</a>
+								<a href="ninepatchverticalscrollbar.html#_bar" class="tsd-kind-icon">_bar</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_barimage" class="tsd-kind-icon">_bar<wbr>Image</a>
+								<a href="ninepatchverticalscrollbar.html#_barimage" class="tsd-kind-icon">_bar<wbr>Image</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_bgrenderer" class="tsd-kind-icon">_bg<wbr>Renderer</a>
+								<a href="ninepatchverticalscrollbar.html#_bgrenderer" class="tsd-kind-icon">_bg<wbr>Renderer</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_bgsurface" class="tsd-kind-icon">_bg<wbr>Surface</a>
+								<a href="ninepatchverticalscrollbar.html#_bgsurface" class="tsd-kind-icon">_bg<wbr>Surface</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_cache" class="tsd-kind-icon">_cache</a>
+								<a href="ninepatchverticalscrollbar.html#_cache" class="tsd-kind-icon">_cache</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_childrenarea" class="tsd-kind-icon">_children<wbr>Area</a>
+								<a href="ninepatchverticalscrollbar.html#_childrenarea" class="tsd-kind-icon">_children<wbr>Area</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_childrenrenderer" class="tsd-kind-icon">_children<wbr>Renderer</a>
+								<a href="ninepatchverticalscrollbar.html#_childrenrenderer" class="tsd-kind-icon">_children<wbr>Renderer</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_childrensurface" class="tsd-kind-icon">_children<wbr>Surface</a>
+								<a href="ninepatchverticalscrollbar.html#_childrensurface" class="tsd-kind-icon">_children<wbr>Surface</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_contentlength" class="tsd-kind-icon">_content<wbr>Length</a>
+								<a href="ninepatchverticalscrollbar.html#_contentlength" class="tsd-kind-icon">_content<wbr>Length</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_delta" class="tsd-kind-icon">_delta</a>
+								<a href="ninepatchverticalscrollbar.html#_delta" class="tsd-kind-icon">_delta</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_deltaorigin" class="tsd-kind-icon">_delta<wbr>Origin</a>
+								<a href="ninepatchverticalscrollbar.html#_deltaorigin" class="tsd-kind-icon">_delta<wbr>Origin</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_hastouchablechildren" class="tsd-kind-icon">_has<wbr>Touchable<wbr>Children</a>
+								<a href="ninepatchverticalscrollbar.html#_hastouchablechildren" class="tsd-kind-icon">_has<wbr>Touchable<wbr>Children</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_matrix" class="tsd-kind-icon">_matrix</a>
+								<a href="ninepatchverticalscrollbar.html#_matrix" class="tsd-kind-icon">_matrix</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_normalizedpadding" class="tsd-kind-icon">_normalized<wbr>Padding</a>
+								<a href="ninepatchverticalscrollbar.html#_normalizedpadding" class="tsd-kind-icon">_normalized<wbr>Padding</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_oldheight" class="tsd-kind-icon">_old<wbr>Height</a>
+								<a href="ninepatchverticalscrollbar.html#_oldheight" class="tsd-kind-icon">_old<wbr>Height</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_oldwidth" class="tsd-kind-icon">_old<wbr>Width</a>
+								<a href="ninepatchverticalscrollbar.html#_oldwidth" class="tsd-kind-icon">_old<wbr>Width</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_padding" class="tsd-kind-icon">_padding</a>
+								<a href="ninepatchverticalscrollbar.html#_padding" class="tsd-kind-icon">_padding</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_paddingchanged" class="tsd-kind-icon">_padding<wbr>Changed</a>
+								<a href="ninepatchverticalscrollbar.html#_paddingchanged" class="tsd-kind-icon">_padding<wbr>Changed</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_renderedcamera" class="tsd-kind-icon">_rendered<wbr>Camera</a>
+								<a href="ninepatchverticalscrollbar.html#_renderedcamera" class="tsd-kind-icon">_rendered<wbr>Camera</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_renderer" class="tsd-kind-icon">_renderer</a>
+								<a href="ninepatchverticalscrollbar.html#_renderer" class="tsd-kind-icon">_renderer</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_shouldrenderchildren" class="tsd-kind-icon">_should<wbr>Render<wbr>Children</a>
+								<a href="ninepatchverticalscrollbar.html#_shouldrenderchildren" class="tsd-kind-icon">_should<wbr>Render<wbr>Children</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_targetcameras" class="tsd-kind-icon">_target<wbr>Cameras</a>
+								<a href="ninepatchverticalscrollbar.html#_targetcameras" class="tsd-kind-icon">_target<wbr>Cameras</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#angle" class="tsd-kind-icon">angle</a>
+								<a href="ninepatchverticalscrollbar.html#angle" class="tsd-kind-icon">angle</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#backgroundeffector" class="tsd-kind-icon">background<wbr>Effector</a>
+								<a href="ninepatchverticalscrollbar.html#backgroundeffector" class="tsd-kind-icon">background<wbr>Effector</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#backgroundimage" class="tsd-kind-icon">background<wbr>Image</a>
+								<a href="ninepatchverticalscrollbar.html#backgroundimage" class="tsd-kind-icon">background<wbr>Image</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#children" class="tsd-kind-icon">children</a>
+								<a href="ninepatchverticalscrollbar.html#children" class="tsd-kind-icon">children</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#compositeoperation" class="tsd-kind-icon">composite<wbr>Operation</a>
+								<a href="ninepatchverticalscrollbar.html#compositeoperation" class="tsd-kind-icon">composite<wbr>Operation</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#height" class="tsd-kind-icon">height</a>
+								<a href="ninepatchverticalscrollbar.html#height" class="tsd-kind-icon">height</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#id" class="tsd-kind-icon">id</a>
+								<a href="ninepatchverticalscrollbar.html#id" class="tsd-kind-icon">id</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#local" class="tsd-kind-icon">local</a>
+								<a href="ninepatchverticalscrollbar.html#local" class="tsd-kind-icon">local</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#message" class="tsd-kind-icon">message</a>
+								<a href="ninepatchverticalscrollbar.html#message" class="tsd-kind-icon">message</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-external">
-								<a href="defaultverticalscrollbar.html#onchangebarpositionrate" class="tsd-kind-icon">on<wbr>Change<wbr>Bar<wbr>Position<wbr>Rate</a>
+								<a href="ninepatchverticalscrollbar.html#onchangebarpositionrate" class="tsd-kind-icon">on<wbr>Change<wbr>Bar<wbr>Position<wbr>Rate</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#opacity" class="tsd-kind-icon">opacity</a>
+								<a href="ninepatchverticalscrollbar.html#opacity" class="tsd-kind-icon">opacity</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#padding" class="tsd-kind-icon">padding</a>
+								<a href="ninepatchverticalscrollbar.html#padding" class="tsd-kind-icon">padding</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#parent" class="tsd-kind-icon">parent</a>
+								<a href="ninepatchverticalscrollbar.html#parent" class="tsd-kind-icon">parent</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#pointdown" class="tsd-kind-icon">point<wbr>Down</a>
+								<a href="ninepatchverticalscrollbar.html#pointdown" class="tsd-kind-icon">point<wbr>Down</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#pointmove" class="tsd-kind-icon">point<wbr>Move</a>
+								<a href="ninepatchverticalscrollbar.html#pointmove" class="tsd-kind-icon">point<wbr>Move</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#pointup" class="tsd-kind-icon">point<wbr>Up</a>
+								<a href="ninepatchverticalscrollbar.html#pointup" class="tsd-kind-icon">point<wbr>Up</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#scalex" class="tsd-kind-icon">scaleX</a>
+								<a href="ninepatchverticalscrollbar.html#scalex" class="tsd-kind-icon">scaleX</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#scaley" class="tsd-kind-icon">scaleY</a>
+								<a href="ninepatchverticalscrollbar.html#scaley" class="tsd-kind-icon">scaleY</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#scene" class="tsd-kind-icon">scene</a>
+								<a href="ninepatchverticalscrollbar.html#scene" class="tsd-kind-icon">scene</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#state" class="tsd-kind-icon">state</a>
+								<a href="ninepatchverticalscrollbar.html#state" class="tsd-kind-icon">state</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#tag" class="tsd-kind-icon">tag</a>
+								<a href="ninepatchverticalscrollbar.html#tag" class="tsd-kind-icon">tag</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#targetcameras" class="tsd-kind-icon">target<wbr>Cameras</a>
+								<a href="ninepatchverticalscrollbar.html#targetcameras" class="tsd-kind-icon">target<wbr>Cameras</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#touchable" class="tsd-kind-icon">touchable</a>
+								<a href="ninepatchverticalscrollbar.html#touchable" class="tsd-kind-icon">touchable</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#update" class="tsd-kind-icon">update</a>
+								<a href="ninepatchverticalscrollbar.html#update" class="tsd-kind-icon">update</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#width" class="tsd-kind-icon">width</a>
+								<a href="ninepatchverticalscrollbar.html#width" class="tsd-kind-icon">width</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#x" class="tsd-kind-icon">x</a>
+								<a href="ninepatchverticalscrollbar.html#x" class="tsd-kind-icon">x</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#y" class="tsd-kind-icon">y</a>
+								<a href="ninepatchverticalscrollbar.html#y" class="tsd-kind-icon">y</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_calculateboundingrect" class="tsd-kind-icon">_calculate<wbr>Bounding<wbr>Rect</a>
+								<a href="ninepatchverticalscrollbar.html#_calculateboundingrect" class="tsd-kind-icon">_calculate<wbr>Bounding<wbr>Rect</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_disabletouchpropagation" class="tsd-kind-icon">_disable<wbr>Touch<wbr>Propagation</a>
+								<a href="ninepatchverticalscrollbar.html#_disabletouchpropagation" class="tsd-kind-icon">_disable<wbr>Touch<wbr>Propagation</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_enabletouchpropagation" class="tsd-kind-icon">_enable<wbr>Touch<wbr>Propagation</a>
+								<a href="ninepatchverticalscrollbar.html#_enabletouchpropagation" class="tsd-kind-icon">_enable<wbr>Touch<wbr>Propagation</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_handlebarpointdown" class="tsd-kind-icon">_handle<wbr>Bar<wbr>Point<wbr>Down</a>
+								<a href="ninepatchverticalscrollbar.html#_handlebarpointdown" class="tsd-kind-icon">_handle<wbr>Bar<wbr>Point<wbr>Down</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_handlebarpointmove" class="tsd-kind-icon">_handle<wbr>Bar<wbr>Point<wbr>Move</a>
+								<a href="ninepatchverticalscrollbar.html#_handlebarpointmove" class="tsd-kind-icon">_handle<wbr>Bar<wbr>Point<wbr>Move</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_initialize" class="tsd-kind-icon">_initialize</a>
+								<a href="ninepatchverticalscrollbar.html#_initialize" class="tsd-kind-icon">_initialize</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_istargetoperation" class="tsd-kind-icon">_is<wbr>Target<wbr>Operation</a>
+								<a href="ninepatchverticalscrollbar.html#_istargetoperation" class="tsd-kind-icon">_is<wbr>Target<wbr>Operation</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_renderbackground" class="tsd-kind-icon">_render<wbr>Background</a>
+								<a href="ninepatchverticalscrollbar.html#_renderbackground" class="tsd-kind-icon">_render<wbr>Background</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_renderchildren" class="tsd-kind-icon">_render<wbr>Children</a>
+								<a href="ninepatchverticalscrollbar.html#_renderchildren" class="tsd-kind-icon">_render<wbr>Children</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-private tsd-is-external">
-								<a href="defaultverticalscrollbar.html#_updatematrix" class="tsd-kind-icon">_update<wbr>Matrix</a>
+								<a href="ninepatchverticalscrollbar.html#_updatematrix" class="tsd-kind-icon">_update<wbr>Matrix</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#append" class="tsd-kind-icon">append</a>
+								<a href="ninepatchverticalscrollbar.html#append" class="tsd-kind-icon">append</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#calculateboundingrect" class="tsd-kind-icon">calculate<wbr>Bounding<wbr>Rect</a>
+								<a href="ninepatchverticalscrollbar.html#calculateboundingrect" class="tsd-kind-icon">calculate<wbr>Bounding<wbr>Rect</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-external">
-								<a href="defaultverticalscrollbar.html#destroy" class="tsd-kind-icon">destroy</a>
+								<a href="ninepatchverticalscrollbar.html#destroy" class="tsd-kind-icon">destroy</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#destroyed" class="tsd-kind-icon">destroyed</a>
+								<a href="ninepatchverticalscrollbar.html#destroyed" class="tsd-kind-icon">destroyed</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#findpointsourcebypoint" class="tsd-kind-icon">find<wbr>Point<wbr>Source<wbr>ByPoint</a>
+								<a href="ninepatchverticalscrollbar.html#findpointsourcebypoint" class="tsd-kind-icon">find<wbr>Point<wbr>Source<wbr>ByPoint</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#game" class="tsd-kind-icon">game</a>
+								<a href="ninepatchverticalscrollbar.html#game" class="tsd-kind-icon">game</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#getmatrix" class="tsd-kind-icon">get<wbr>Matrix</a>
+								<a href="ninepatchverticalscrollbar.html#getmatrix" class="tsd-kind-icon">get<wbr>Matrix</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#hide" class="tsd-kind-icon">hide</a>
+								<a href="ninepatchverticalscrollbar.html#hide" class="tsd-kind-icon">hide</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#insertbefore" class="tsd-kind-icon">insert<wbr>Before</a>
+								<a href="ninepatchverticalscrollbar.html#insertbefore" class="tsd-kind-icon">insert<wbr>Before</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#invalidate" class="tsd-kind-icon">invalidate</a>
+								<a href="ninepatchverticalscrollbar.html#invalidate" class="tsd-kind-icon">invalidate</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#modified" class="tsd-kind-icon">modified</a>
+								<a href="ninepatchverticalscrollbar.html#modified" class="tsd-kind-icon">modified</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#moveby" class="tsd-kind-icon">move<wbr>By</a>
+								<a href="ninepatchverticalscrollbar.html#moveby" class="tsd-kind-icon">move<wbr>By</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#moveto" class="tsd-kind-icon">move<wbr>To</a>
+								<a href="ninepatchverticalscrollbar.html#moveto" class="tsd-kind-icon">move<wbr>To</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#remove" class="tsd-kind-icon">remove</a>
+								<a href="ninepatchverticalscrollbar.html#remove" class="tsd-kind-icon">remove</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#render" class="tsd-kind-icon">render</a>
+								<a href="ninepatchverticalscrollbar.html#render" class="tsd-kind-icon">render</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#rendercache" class="tsd-kind-icon">render<wbr>Cache</a>
+								<a href="ninepatchverticalscrollbar.html#rendercache" class="tsd-kind-icon">render<wbr>Cache</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#renderself" class="tsd-kind-icon">render<wbr>Self</a>
+								<a href="ninepatchverticalscrollbar.html#renderself" class="tsd-kind-icon">render<wbr>Self</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#resizeby" class="tsd-kind-icon">resize<wbr>By</a>
+								<a href="ninepatchverticalscrollbar.html#resizeby" class="tsd-kind-icon">resize<wbr>By</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#resizeto" class="tsd-kind-icon">resize<wbr>To</a>
+								<a href="ninepatchverticalscrollbar.html#resizeto" class="tsd-kind-icon">resize<wbr>To</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#scale" class="tsd-kind-icon">scale</a>
+								<a href="ninepatchverticalscrollbar.html#scale" class="tsd-kind-icon">scale</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-external">
-								<a href="defaultverticalscrollbar.html#setbarproperties" class="tsd-kind-icon">set<wbr>Bar<wbr>Properties</a>
+								<a href="ninepatchverticalscrollbar.html#setbarproperties" class="tsd-kind-icon">set<wbr>Bar<wbr>Properties</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#shouldfindchildrenbypoint" class="tsd-kind-icon">should<wbr>Find<wbr>Children<wbr>ByPoint</a>
+								<a href="ninepatchverticalscrollbar.html#shouldfindchildrenbypoint" class="tsd-kind-icon">should<wbr>Find<wbr>Children<wbr>ByPoint</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#show" class="tsd-kind-icon">show</a>
+								<a href="ninepatchverticalscrollbar.html#show" class="tsd-kind-icon">show</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-external">
-								<a href="defaultverticalscrollbar.html#visible" class="tsd-kind-icon">visible</a>
+								<a href="ninepatchverticalscrollbar.html#visible" class="tsd-kind-icon">visible</a>
 							</li>
 						</ul>
 					</li>
@@ -2334,10 +2334,10 @@
 						<a href="scrolledcontentcontainer.html" class="tsd-kind-icon">Scrolled<wbr>Content<wbr>Container</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
-						<a href="../interfaces/defaulthorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="../interfaces/ninepatchhorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
-						<a href="../interfaces/defaultverticalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="../interfaces/ninepatchverticalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
 						<a href="../interfaces/scrollableparameterobject.html" class="tsd-kind-icon">Scrollable<wbr>Parameter<wbr>Object</a>
@@ -2346,7 +2346,7 @@
 						<a href="../interfaces/scrollbaroperations.html" class="tsd-kind-icon">Scrollbar<wbr>Operations</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-is-external">
-						<a href="../globals.html#scrollbarlike" class="tsd-kind-icon">Scrollbar<wbr>Like</a>
+						<a href="../globals.html#scrollbar" class="tsd-kind-icon">Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-function tsd-is-external">
 						<a href="../globals.html#createdefaultscrollbarimage" class="tsd-kind-icon">create<wbr>Default<wbr>Scrollbar<wbr>Image</a>

--- a/docs/apiref/classes/nullscrollbar.html
+++ b/docs/apiref/classes/nullscrollbar.html
@@ -178,7 +178,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides E.__constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/NullScrollbar.ts#L4">NullScrollbar.ts:4</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NullScrollbar.ts#L4">NullScrollbar.ts:4</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -379,7 +379,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/scrollbaroperations.html">ScrollbarOperations</a>.<a href="../interfaces/scrollbaroperations.html#onchangebarpositionrate">onChangeBarPositionRate</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/NullScrollbar.ts#L4">NullScrollbar.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NullScrollbar.ts#L4">NullScrollbar.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -855,7 +855,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides E.destroy</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/NullScrollbar.ts#L11">NullScrollbar.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NullScrollbar.ts#L11">NullScrollbar.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1464,7 +1464,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/scrollbaroperations.html">ScrollbarOperations</a>.<a href="../interfaces/scrollbaroperations.html#setbarproperties">setBarProperties</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/NullScrollbar.ts#L16">NullScrollbar.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NullScrollbar.ts#L16">NullScrollbar.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1579,10 +1579,10 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-is-external">
-						<a href="defaulthorizontalscrollbar.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar</a>
+						<a href="ninepatchhorizontalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-class tsd-is-external">
-						<a href="defaultverticalscrollbar.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar</a>
+						<a href="ninepatchverticalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar</a>
 					</li>
 				</ul>
 				<ul class="current">
@@ -1768,10 +1768,10 @@
 						<a href="scrolledcontentcontainer.html" class="tsd-kind-icon">Scrolled<wbr>Content<wbr>Container</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
-						<a href="../interfaces/defaulthorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="../interfaces/ninepatchhorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
-						<a href="../interfaces/defaultverticalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="../interfaces/ninepatchverticalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
 						<a href="../interfaces/scrollableparameterobject.html" class="tsd-kind-icon">Scrollable<wbr>Parameter<wbr>Object</a>
@@ -1780,7 +1780,7 @@
 						<a href="../interfaces/scrollbaroperations.html" class="tsd-kind-icon">Scrollbar<wbr>Operations</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-is-external">
-						<a href="../globals.html#scrollbarlike" class="tsd-kind-icon">Scrollbar<wbr>Like</a>
+						<a href="../globals.html#scrollbar" class="tsd-kind-icon">Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-function tsd-is-external">
 						<a href="../globals.html#createdefaultscrollbarimage" class="tsd-kind-icon">create<wbr>Default<wbr>Scrollbar<wbr>Image</a>

--- a/docs/apiref/classes/scrollable.html
+++ b/docs/apiref/classes/scrollable.html
@@ -240,7 +240,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides E.__constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L236">Scrollable.ts:236</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L236">Scrollable.ts:236</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 					<div class="tsd-signature tsd-kind-icon">_api<wbr>Requested<wbr>OffsetX<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L165">Scrollable.ts:165</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L165">Scrollable.ts:165</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -278,7 +278,7 @@
 					<div class="tsd-signature tsd-kind-icon">_api<wbr>Requested<wbr>OffsetY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L166">Scrollable.ts:166</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L166">Scrollable.ts:166</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -288,7 +288,7 @@
 					<div class="tsd-signature tsd-kind-icon">_bar<wbr>Image<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Surface</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L133">Scrollable.ts:133</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L133">Scrollable.ts:133</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -298,7 +298,7 @@
 					<div class="tsd-signature tsd-kind-icon">_before<wbr>Height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L168">Scrollable.ts:168</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L168">Scrollable.ts:168</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -308,7 +308,7 @@
 					<div class="tsd-signature tsd-kind-icon">_before<wbr>Width<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L167">Scrollable.ts:167</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L167">Scrollable.ts:167</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -318,7 +318,7 @@
 					<div class="tsd-signature tsd-kind-icon">_bg<wbr>Image<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Surface</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L132">Scrollable.ts:132</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L132">Scrollable.ts:132</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -328,7 +328,7 @@
 					<div class="tsd-signature tsd-kind-icon">_content<wbr>Bounding<wbr>Height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L156">Scrollable.ts:156</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L156">Scrollable.ts:156</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -338,7 +338,7 @@
 					<div class="tsd-signature tsd-kind-icon">_content<wbr>Bounding<wbr>Width<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L155">Scrollable.ts:155</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L155">Scrollable.ts:155</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -348,7 +348,7 @@
 					<div class="tsd-signature tsd-kind-icon">_content<wbr>Container<span class="tsd-signature-symbol">:</span> <a href="scrolledcontentcontainer.html" class="tsd-signature-type">ScrolledContentContainer</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L144">Scrollable.ts:144</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L144">Scrollable.ts:144</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -358,7 +358,7 @@
 					<div class="tsd-signature tsd-kind-icon">_deltaX<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L163">Scrollable.ts:163</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L163">Scrollable.ts:163</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -368,7 +368,7 @@
 					<div class="tsd-signature tsd-kind-icon">_deltaY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L164">Scrollable.ts:164</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L164">Scrollable.ts:164</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -378,7 +378,7 @@
 					<div class="tsd-signature tsd-kind-icon">_extra<wbr>Draw<wbr>OffsetX<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L141">Scrollable.ts:141</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L141">Scrollable.ts:141</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -388,7 +388,7 @@
 					<div class="tsd-signature tsd-kind-icon">_extra<wbr>Draw<wbr>OffsetY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L142">Scrollable.ts:142</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L142">Scrollable.ts:142</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -398,7 +398,7 @@
 					<div class="tsd-signature tsd-kind-icon">_extra<wbr>Draw<wbr>Size<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L140">Scrollable.ts:140</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L140">Scrollable.ts:140</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -421,10 +421,10 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external">
 					<a name="_horizontalbar" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagPrivate">Private</span> _horizontal<wbr>Bar</h3>
-					<div class="tsd-signature tsd-kind-icon">_horizontal<wbr>Bar<span class="tsd-signature-symbol">:</span> <a href="../globals.html#scrollbarlike" class="tsd-signature-type">ScrollbarLike</a></div>
+					<div class="tsd-signature tsd-kind-icon">_horizontal<wbr>Bar<span class="tsd-signature-symbol">:</span> <a href="../globals.html#scrollbar" class="tsd-signature-type">Scrollbar</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L145">Scrollable.ts:145</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L145">Scrollable.ts:145</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -434,7 +434,7 @@
 					<div class="tsd-signature tsd-kind-icon">_inset<wbr>Bars<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L138">Scrollable.ts:138</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L138">Scrollable.ts:138</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -444,7 +444,7 @@
 					<div class="tsd-signature tsd-kind-icon">_is<wbr>Cached<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L150">Scrollable.ts:150</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L150">Scrollable.ts:150</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -454,7 +454,7 @@
 					<div class="tsd-signature tsd-kind-icon">_is<wbr>Flush<wbr>Requested<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L160">Scrollable.ts:160</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L160">Scrollable.ts:160</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -464,7 +464,7 @@
 					<div class="tsd-signature tsd-kind-icon">_is<wbr>Horizontal<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L136">Scrollable.ts:136</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L136">Scrollable.ts:136</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -474,7 +474,7 @@
 					<div class="tsd-signature tsd-kind-icon">_is<wbr>Update<wbr>Bounding<wbr>Rect<wbr>Requested<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L157">Scrollable.ts:157</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L157">Scrollable.ts:157</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -484,7 +484,7 @@
 					<div class="tsd-signature tsd-kind-icon">_is<wbr>Update<wbr>Content<wbr>Scroll<wbr>Requested<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L158">Scrollable.ts:158</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L158">Scrollable.ts:158</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -494,7 +494,7 @@
 					<div class="tsd-signature tsd-kind-icon">_is<wbr>Update<wbr>Scrollbar<wbr>Requested<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L159">Scrollable.ts:159</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L159">Scrollable.ts:159</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -504,7 +504,7 @@
 					<div class="tsd-signature tsd-kind-icon">_is<wbr>Vertical<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L135">Scrollable.ts:135</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L135">Scrollable.ts:135</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -514,7 +514,7 @@
 					<div class="tsd-signature tsd-kind-icon">_last<wbr>Notified<wbr>Horizontal<wbr>Rate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L162">Scrollable.ts:162</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L162">Scrollable.ts:162</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -524,7 +524,7 @@
 					<div class="tsd-signature tsd-kind-icon">_last<wbr>Notified<wbr>Vertical<wbr>Rate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L161">Scrollable.ts:161</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L161">Scrollable.ts:161</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -555,7 +555,7 @@
 					<div class="tsd-signature tsd-kind-icon">_render<wbr>OffsetX<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L153">Scrollable.ts:153</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L153">Scrollable.ts:153</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -565,7 +565,7 @@
 					<div class="tsd-signature tsd-kind-icon">_render<wbr>OffsetY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L154">Scrollable.ts:154</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L154">Scrollable.ts:154</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -575,7 +575,7 @@
 					<div class="tsd-signature tsd-kind-icon">_rendered<wbr>Camera<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Camera</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L151">Scrollable.ts:151</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L151">Scrollable.ts:151</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -585,7 +585,7 @@
 					<div class="tsd-signature tsd-kind-icon">_renderer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Renderer</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L149">Scrollable.ts:149</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L149">Scrollable.ts:149</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -595,7 +595,7 @@
 					<div class="tsd-signature tsd-kind-icon">_surface<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Surface</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L148">Scrollable.ts:148</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L148">Scrollable.ts:148</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -623,17 +623,17 @@
 					<div class="tsd-signature tsd-kind-icon">_touch<wbr>Scroll<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L137">Scrollable.ts:137</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L137">Scrollable.ts:137</a></li>
 						</ul>
 					</aside>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-external">
 					<a name="_verticalbar" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagPrivate">Private</span> _vertical<wbr>Bar</h3>
-					<div class="tsd-signature tsd-kind-icon">_vertical<wbr>Bar<span class="tsd-signature-symbol">:</span> <a href="../globals.html#scrollbarlike" class="tsd-signature-type">ScrollbarLike</a></div>
+					<div class="tsd-signature tsd-kind-icon">_vertical<wbr>Bar<span class="tsd-signature-symbol">:</span> <a href="../globals.html#scrollbar" class="tsd-signature-type">Scrollbar</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L146">Scrollable.ts:146</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L146">Scrollable.ts:146</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -1049,7 +1049,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L178">Scrollable.ts:178</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L178">Scrollable.ts:178</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1075,7 +1075,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L185">Scrollable.ts:185</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L185">Scrollable.ts:185</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1102,7 +1102,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L203">Scrollable.ts:203</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L203">Scrollable.ts:203</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1118,7 +1118,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L220">Scrollable.ts:220</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L220">Scrollable.ts:220</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1153,7 +1153,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L212">Scrollable.ts:212</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L212">Scrollable.ts:212</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1169,7 +1169,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L232">Scrollable.ts:232</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L232">Scrollable.ts:232</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1203,7 +1203,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L192">Scrollable.ts:192</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L192">Scrollable.ts:192</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1301,7 +1301,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L473">Scrollable.ts:473</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L473">Scrollable.ts:473</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1318,7 +1318,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L419">Scrollable.ts:419</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L419">Scrollable.ts:419</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1335,7 +1335,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L428">Scrollable.ts:428</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L428">Scrollable.ts:428</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1358,7 +1358,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L423">Scrollable.ts:423</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L423">Scrollable.ts:423</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1381,7 +1381,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L433">Scrollable.ts:433</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L433">Scrollable.ts:433</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1430,7 +1430,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L555">Scrollable.ts:555</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L555">Scrollable.ts:555</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1453,7 +1453,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L459">Scrollable.ts:459</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L459">Scrollable.ts:459</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1470,7 +1470,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L441">Scrollable.ts:441</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L441">Scrollable.ts:441</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1487,7 +1487,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L453">Scrollable.ts:453</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L453">Scrollable.ts:453</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1504,7 +1504,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L447">Scrollable.ts:447</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L447">Scrollable.ts:447</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1521,7 +1521,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L490">Scrollable.ts:490</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L490">Scrollable.ts:490</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1538,7 +1538,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L511">Scrollable.ts:511</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L511">Scrollable.ts:511</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1578,7 +1578,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L548">Scrollable.ts:548</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L548">Scrollable.ts:548</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1660,7 +1660,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides E.destroy</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L315">Scrollable.ts:315</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L315">Scrollable.ts:315</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1875,7 +1875,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides E.modified</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L377">Scrollable.ts:377</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L377">Scrollable.ts:377</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2085,7 +2085,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides E.renderSelf</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L348">Scrollable.ts:348</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L348">Scrollable.ts:348</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2260,7 +2260,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides E.shouldFindChildrenByPoint</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L413">Scrollable.ts:413</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L413">Scrollable.ts:413</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2342,10 +2342,10 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-is-external">
-						<a href="defaulthorizontalscrollbar.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar</a>
+						<a href="ninepatchhorizontalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-class tsd-is-external">
-						<a href="defaultverticalscrollbar.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar</a>
+						<a href="ninepatchverticalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-class tsd-is-external">
 						<a href="nullscrollbar.html" class="tsd-kind-icon">Null<wbr>Scrollbar</a>
@@ -2675,10 +2675,10 @@
 						<a href="scrolledcontentcontainer.html" class="tsd-kind-icon">Scrolled<wbr>Content<wbr>Container</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
-						<a href="../interfaces/defaulthorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="../interfaces/ninepatchhorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
-						<a href="../interfaces/defaultverticalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="../interfaces/ninepatchverticalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
 						<a href="../interfaces/scrollableparameterobject.html" class="tsd-kind-icon">Scrollable<wbr>Parameter<wbr>Object</a>
@@ -2687,7 +2687,7 @@
 						<a href="../interfaces/scrollbaroperations.html" class="tsd-kind-icon">Scrollbar<wbr>Operations</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-is-external">
-						<a href="../globals.html#scrollbarlike" class="tsd-kind-icon">Scrollbar<wbr>Like</a>
+						<a href="../globals.html#scrollbar" class="tsd-kind-icon">Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-function tsd-is-external">
 						<a href="../globals.html#createdefaultscrollbarimage" class="tsd-kind-icon">create<wbr>Default<wbr>Scrollbar<wbr>Image</a>

--- a/docs/apiref/classes/scrolledcontent.html
+++ b/docs/apiref/classes/scrolledcontent.html
@@ -176,7 +176,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides E.__constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L8">Scrollable.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L8">Scrollable.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -376,7 +376,7 @@
 					<div class="tsd-signature tsd-kind-icon">on<wbr>Modified<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Trigger</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L8">Scrollable.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L8">Scrollable.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -852,7 +852,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides E.destroy</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L13">Scrollable.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L13">Scrollable.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1061,7 +1061,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides E.modified</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L17">Scrollable.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L17">Scrollable.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1532,10 +1532,10 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-is-external">
-						<a href="defaulthorizontalscrollbar.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar</a>
+						<a href="ninepatchhorizontalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-class tsd-is-external">
-						<a href="defaultverticalscrollbar.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar</a>
+						<a href="ninepatchverticalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-class tsd-is-external">
 						<a href="nullscrollbar.html" class="tsd-kind-icon">Null<wbr>Scrollbar</a>
@@ -1718,10 +1718,10 @@
 						<a href="scrolledcontentcontainer.html" class="tsd-kind-icon">Scrolled<wbr>Content<wbr>Container</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
-						<a href="../interfaces/defaulthorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="../interfaces/ninepatchhorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
-						<a href="../interfaces/defaultverticalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="../interfaces/ninepatchverticalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
 						<a href="../interfaces/scrollableparameterobject.html" class="tsd-kind-icon">Scrollable<wbr>Parameter<wbr>Object</a>
@@ -1730,7 +1730,7 @@
 						<a href="../interfaces/scrollbaroperations.html" class="tsd-kind-icon">Scrollbar<wbr>Operations</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-is-external">
-						<a href="../globals.html#scrollbarlike" class="tsd-kind-icon">Scrollbar<wbr>Like</a>
+						<a href="../globals.html#scrollbar" class="tsd-kind-icon">Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-function tsd-is-external">
 						<a href="../globals.html#createdefaultscrollbarimage" class="tsd-kind-icon">create<wbr>Default<wbr>Scrollbar<wbr>Image</a>

--- a/docs/apiref/classes/scrolledcontentcontainer.html
+++ b/docs/apiref/classes/scrolledcontentcontainer.html
@@ -180,7 +180,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides E.__constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L26">Scrollable.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L26">Scrollable.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -202,7 +202,7 @@
 					<div class="tsd-signature tsd-kind-icon">_content<span class="tsd-signature-symbol">:</span> <a href="scrolledcontent.html" class="tsd-signature-type">ScrolledContent</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L26">Scrollable.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L26">Scrollable.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -249,7 +249,7 @@
 					<div class="tsd-signature tsd-kind-icon">_offset<wbr>Container<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">E</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L25">Scrollable.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L25">Scrollable.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -400,7 +400,7 @@
 					<div class="tsd-signature tsd-kind-icon">on<wbr>Content<wbr>Modified<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Trigger</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L24">Scrollable.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L24">Scrollable.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -875,7 +875,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L45">Scrollable.ts:45</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L45">Scrollable.ts:45</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">E</span></h4>
@@ -893,7 +893,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides E.destroy</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L36">Scrollable.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L36">Scrollable.ts:36</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1245,7 +1245,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L41">Scrollable.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L41">Scrollable.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">E</span></h4>
@@ -1604,10 +1604,10 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-is-external">
-						<a href="defaulthorizontalscrollbar.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar</a>
+						<a href="ninepatchhorizontalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-class tsd-is-external">
-						<a href="defaultverticalscrollbar.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar</a>
+						<a href="ninepatchverticalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-class tsd-is-external">
 						<a href="nullscrollbar.html" class="tsd-kind-icon">Null<wbr>Scrollbar</a>
@@ -1802,10 +1802,10 @@
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-interface tsd-is-external">
-						<a href="../interfaces/defaulthorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="../interfaces/ninepatchhorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
-						<a href="../interfaces/defaultverticalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="../interfaces/ninepatchverticalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
 						<a href="../interfaces/scrollableparameterobject.html" class="tsd-kind-icon">Scrollable<wbr>Parameter<wbr>Object</a>
@@ -1814,7 +1814,7 @@
 						<a href="../interfaces/scrollbaroperations.html" class="tsd-kind-icon">Scrollbar<wbr>Operations</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-is-external">
-						<a href="../globals.html#scrollbarlike" class="tsd-kind-icon">Scrollbar<wbr>Like</a>
+						<a href="../globals.html#scrollbar" class="tsd-kind-icon">Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-function tsd-is-external">
 						<a href="../globals.html#createdefaultscrollbarimage" class="tsd-kind-icon">create<wbr>Default<wbr>Scrollbar<wbr>Image</a>

--- a/docs/apiref/globals.html
+++ b/docs/apiref/globals.html
@@ -70,8 +70,8 @@
 						<section class="tsd-index-section tsd-is-external">
 							<h3>Classes</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-class tsd-is-external"><a href="classes/defaulthorizontalscrollbar.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar</a></li>
-								<li class="tsd-kind-class tsd-is-external"><a href="classes/defaultverticalscrollbar.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar</a></li>
+								<li class="tsd-kind-class tsd-is-external"><a href="classes/ninepatchhorizontalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar</a></li>
+								<li class="tsd-kind-class tsd-is-external"><a href="classes/ninepatchverticalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar</a></li>
 								<li class="tsd-kind-class tsd-is-external"><a href="classes/nullscrollbar.html" class="tsd-kind-icon">Null<wbr>Scrollbar</a></li>
 								<li class="tsd-kind-class tsd-is-external"><a href="classes/scrollable.html" class="tsd-kind-icon">Scrollable</a></li>
 								<li class="tsd-kind-class tsd-is-external"><a href="classes/scrolledcontent.html" class="tsd-kind-icon">Scrolled<wbr>Content</a></li>
@@ -81,8 +81,8 @@
 						<section class="tsd-index-section tsd-is-external">
 							<h3>Interfaces</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-interface tsd-is-external"><a href="interfaces/defaulthorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a></li>
-								<li class="tsd-kind-interface tsd-is-external"><a href="interfaces/defaultverticalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a></li>
+								<li class="tsd-kind-interface tsd-is-external"><a href="interfaces/ninepatchhorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a></li>
+								<li class="tsd-kind-interface tsd-is-external"><a href="interfaces/ninepatchverticalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a></li>
 								<li class="tsd-kind-interface tsd-is-external"><a href="interfaces/scrollableparameterobject.html" class="tsd-kind-icon">Scrollable<wbr>Parameter<wbr>Object</a></li>
 								<li class="tsd-kind-interface tsd-is-external"><a href="interfaces/scrollbaroperations.html" class="tsd-kind-icon">Scrollbar<wbr>Operations</a></li>
 							</ul>
@@ -90,7 +90,7 @@
 						<section class="tsd-index-section tsd-is-external">
 							<h3>Type aliases</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-type-alias tsd-is-external"><a href="globals.html#scrollbarlike" class="tsd-kind-icon">Scrollbar<wbr>Like</a></li>
+								<li class="tsd-kind-type-alias tsd-is-external"><a href="globals.html#scrollbar" class="tsd-kind-icon">Scrollbar</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-external">
@@ -112,12 +112,12 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-external">
 				<h2>Type aliases</h2>
 				<section class="tsd-panel tsd-member tsd-kind-type-alias tsd-is-external">
-					<a name="scrollbarlike" class="tsd-anchor"></a>
-					<h3>Scrollbar<wbr>Like</h3>
-					<div class="tsd-signature tsd-kind-icon">Scrollbar<wbr>Like<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">E</span><span class="tsd-signature-symbol"> &amp; </span><a href="interfaces/scrollbaroperations.html" class="tsd-signature-type">ScrollbarOperations</a></div>
+					<a name="scrollbar" class="tsd-anchor"></a>
+					<h3>Scrollbar</h3>
+					<div class="tsd-signature tsd-kind-icon">Scrollbar<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">E</span><span class="tsd-signature-symbol"> &amp; </span><a href="interfaces/scrollbaroperations.html" class="tsd-signature-type">ScrollbarOperations</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/ScrollbarLike.ts#L34">ScrollbarLike.ts:34</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollbar.ts#L34">Scrollbar.ts:34</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -140,7 +140,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/createDefaultScrollbarImage.ts#L30">createDefaultScrollbarImage.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/createDefaultScrollbarImage.ts#L30">createDefaultScrollbarImage.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -196,7 +196,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/createDefaultScrollbarImage.ts#L13">createDefaultScrollbarImage.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/createDefaultScrollbarImage.ts#L13">createDefaultScrollbarImage.ts:13</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -253,7 +253,7 @@
 					<div class="tsd-signature tsd-kind-icon">internal<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/index.ts#L8">index.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/index.ts#L8">index.ts:8</a></li>
 						</ul>
 					</aside>
 					<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -262,7 +262,7 @@
 						<div class="tsd-signature tsd-kind-icon">Scrolled<wbr>Content<span class="tsd-signature-symbol">:</span> <a href="classes/scrolledcontent.html" class="tsd-signature-type">ScrolledContent</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/index.ts#L8">index.ts:8</a></li>
+								<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/index.ts#L8">index.ts:8</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -272,7 +272,7 @@
 						<div class="tsd-signature tsd-kind-icon">Scrolled<wbr>Content<wbr>Container<span class="tsd-signature-symbol">:</span> <a href="classes/scrolledcontentcontainer.html" class="tsd-signature-type">ScrolledContentContainer</a></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/index.ts#L8">index.ts:8</a></li>
+								<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/index.ts#L8">index.ts:8</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -290,10 +290,10 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-is-external">
-						<a href="classes/defaulthorizontalscrollbar.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar</a>
+						<a href="classes/ninepatchhorizontalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-class tsd-is-external">
-						<a href="classes/defaultverticalscrollbar.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar</a>
+						<a href="classes/ninepatchverticalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-class tsd-is-external">
 						<a href="classes/nullscrollbar.html" class="tsd-kind-icon">Null<wbr>Scrollbar</a>
@@ -308,10 +308,10 @@
 						<a href="classes/scrolledcontentcontainer.html" class="tsd-kind-icon">Scrolled<wbr>Content<wbr>Container</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
-						<a href="interfaces/defaulthorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="interfaces/ninepatchhorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
-						<a href="interfaces/defaultverticalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="interfaces/ninepatchverticalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
 						<a href="interfaces/scrollableparameterobject.html" class="tsd-kind-icon">Scrollable<wbr>Parameter<wbr>Object</a>
@@ -320,7 +320,7 @@
 						<a href="interfaces/scrollbaroperations.html" class="tsd-kind-icon">Scrollbar<wbr>Operations</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-is-external">
-						<a href="globals.html#scrollbarlike" class="tsd-kind-icon">Scrollbar<wbr>Like</a>
+						<a href="globals.html#scrollbar" class="tsd-kind-icon">Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-function tsd-is-external">
 						<a href="globals.html#createdefaultscrollbarimage" class="tsd-kind-icon">create<wbr>Default<wbr>Scrollbar<wbr>Image</a>

--- a/docs/apiref/index.html
+++ b/docs/apiref/index.html
@@ -67,7 +67,7 @@
 				<h1 id="akashic-scrollable">akashic-scrollable</h1>
 				<p><strong>akashic-scrollable</strong> is a library for <a href="https://akashic-games.github.io/">Akashic Engine</a> that provides scrolling/clipping entites.</p>
 				<blockquote>
-					<p>日本語の文書は [こちら][guide-ja] 。</p>
+					<p>日本語の文書は <a href="https://xnv.github.io/akashic-scrollable/book/ja/">こちら</a> 。</p>
 					<p>Unfortunately, Akashic Engine does not provide English documentation yet.
 						Whole this library is documented in English just to be prepared for their future translation.
 					You need to know Japanese to use this library in practice, at least currently.</p>
@@ -83,9 +83,9 @@
 				<h2 id="documents">Documents</h2>
 				<p>will be written later.</p>
 				<ul>
-					<li>[Guide][guide] or [利用ガイド (ja)][guide-ja]</li>
+					<li><a href="https://xnv.github.io/akashic-scrollable/book/en/">Guide</a> or <a href="https://xnv.github.io/akashic-scrollable/book/ja/">利用ガイド (ja)</a></li>
 					<li>[Demo][demo]</li>
-					<li>[API Reference][apiref]</li>
+					<li><a href="https://xnv.github.io/akashic-scrollable/apiref/index.html">API Reference</a></li>
 				</ul>
 				<h2 id="license">License</h2>
 				<p>MIT. See LICENSE for detail.</p>
@@ -102,10 +102,10 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-is-external">
-						<a href="classes/defaulthorizontalscrollbar.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar</a>
+						<a href="classes/ninepatchhorizontalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-class tsd-is-external">
-						<a href="classes/defaultverticalscrollbar.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar</a>
+						<a href="classes/ninepatchverticalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-class tsd-is-external">
 						<a href="classes/nullscrollbar.html" class="tsd-kind-icon">Null<wbr>Scrollbar</a>
@@ -120,10 +120,10 @@
 						<a href="classes/scrolledcontentcontainer.html" class="tsd-kind-icon">Scrolled<wbr>Content<wbr>Container</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
-						<a href="interfaces/defaulthorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="interfaces/ninepatchhorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
-						<a href="interfaces/defaultverticalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="interfaces/ninepatchverticalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
 						<a href="interfaces/scrollableparameterobject.html" class="tsd-kind-icon">Scrollable<wbr>Parameter<wbr>Object</a>
@@ -132,7 +132,7 @@
 						<a href="interfaces/scrollbaroperations.html" class="tsd-kind-icon">Scrollbar<wbr>Operations</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-is-external">
-						<a href="globals.html#scrollbarlike" class="tsd-kind-icon">Scrollbar<wbr>Like</a>
+						<a href="globals.html#scrollbar" class="tsd-kind-icon">Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-function tsd-is-external">
 						<a href="globals.html#createdefaultscrollbarimage" class="tsd-kind-icon">create<wbr>Default<wbr>Scrollbar<wbr>Image</a>

--- a/docs/apiref/interfaces/ninepatchhorizontalscrollbarparameterobject.html
+++ b/docs/apiref/interfaces/ninepatchhorizontalscrollbarparameterobject.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<title>DefaultHorizontalScrollbarParameterObject | @xnv/akashic-scrollable</title>
+	<title>NinePatchHorizontalScrollbarParameterObject | @xnv/akashic-scrollable</title>
 	<meta name="description" content="">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="stylesheet" href="../assets/css/main.css">
@@ -56,10 +56,10 @@
 					<a href="../globals.html">Globals</a>
 				</li>
 				<li>
-					<a href="defaulthorizontalscrollbarparameterobject.html">DefaultHorizontalScrollbarParameterObject</a>
+					<a href="ninepatchhorizontalscrollbarparameterobject.html">NinePatchHorizontalScrollbarParameterObject</a>
 				</li>
 			</ul>
-			<h1>Interface DefaultHorizontalScrollbarParameterObject</h1>
+			<h1>Interface NinePatchHorizontalScrollbarParameterObject</h1>
 		</div>
 	</div>
 </header>
@@ -69,16 +69,16 @@
 			<section class="tsd-panel tsd-comment">
 				<div class="tsd-comment tsd-typography">
 					<div class="lead">
-						<p>The type of the argument of <code>new DefaultHorizontalScrollbar()</code>.</p>
+						<p>The type of the argument of <code>new NinePatchHorizontalScrollbar()</code>.</p>
 					</div>
-					<p><code>new DefaultHorizontalScrollbar()</code> の引数の型。</p>
+					<p><code>new NinePatchHorizontalScrollbar()</code> の引数の型。</p>
 				</div>
 			</section>
 			<section class="tsd-panel tsd-hierarchy">
 				<h3>Hierarchy</h3>
 				<ul class="tsd-hierarchy">
 					<li>
-						<span class="target">DefaultHorizontalScrollbarParameterObject</span>
+						<span class="target">NinePatchHorizontalScrollbarParameterObject</span>
 					</li>
 				</ul>
 			</section>
@@ -89,9 +89,9 @@
 						<section class="tsd-index-section tsd-is-external">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"><a href="defaulthorizontalscrollbarparameterobject.html#bgimage" class="tsd-kind-icon">bg<wbr>Image</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"><a href="defaulthorizontalscrollbarparameterobject.html#image" class="tsd-kind-icon">image</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"><a href="defaulthorizontalscrollbarparameterobject.html#scene" class="tsd-kind-icon">scene</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"><a href="ninepatchhorizontalscrollbarparameterobject.html#bgimage" class="tsd-kind-icon">bg<wbr>Image</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"><a href="ninepatchhorizontalscrollbarparameterobject.html#image" class="tsd-kind-icon">image</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"><a href="ninepatchhorizontalscrollbarparameterobject.html#scene" class="tsd-kind-icon">scene</a></li>
 							</ul>
 						</section>
 					</div>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">bg<wbr>Image<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Surface</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultHorizontalScrollbar.ts#L10">DefaultHorizontalScrollbar.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchHorizontalScrollbar.ts#L10">NinePatchHorizontalScrollbar.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">image<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Surface</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultHorizontalScrollbar.ts#L11">DefaultHorizontalScrollbar.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchHorizontalScrollbar.ts#L11">NinePatchHorizontalScrollbar.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">scene<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Scene</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultHorizontalScrollbar.ts#L9">DefaultHorizontalScrollbar.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchHorizontalScrollbar.ts#L9">NinePatchHorizontalScrollbar.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,10 +142,10 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-is-external">
-						<a href="../classes/defaulthorizontalscrollbar.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar</a>
+						<a href="../classes/ninepatchhorizontalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-class tsd-is-external">
-						<a href="../classes/defaultverticalscrollbar.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar</a>
+						<a href="../classes/ninepatchverticalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-class tsd-is-external">
 						<a href="../classes/nullscrollbar.html" class="tsd-kind-icon">Null<wbr>Scrollbar</a>
@@ -162,23 +162,23 @@
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-interface tsd-is-external">
-						<a href="defaulthorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="ninepatchhorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 						<ul>
 							<li class=" tsd-kind-property tsd-parent-kind-interface tsd-is-external">
-								<a href="defaulthorizontalscrollbarparameterobject.html#bgimage" class="tsd-kind-icon">bg<wbr>Image</a>
+								<a href="ninepatchhorizontalscrollbarparameterobject.html#bgimage" class="tsd-kind-icon">bg<wbr>Image</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-interface tsd-is-external">
-								<a href="defaulthorizontalscrollbarparameterobject.html#image" class="tsd-kind-icon">image</a>
+								<a href="ninepatchhorizontalscrollbarparameterobject.html#image" class="tsd-kind-icon">image</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-interface tsd-is-external">
-								<a href="defaulthorizontalscrollbarparameterobject.html#scene" class="tsd-kind-icon">scene</a>
+								<a href="ninepatchhorizontalscrollbarparameterobject.html#scene" class="tsd-kind-icon">scene</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-interface tsd-is-external">
-						<a href="defaultverticalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="ninepatchverticalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
 						<a href="scrollableparameterobject.html" class="tsd-kind-icon">Scrollable<wbr>Parameter<wbr>Object</a>
@@ -187,7 +187,7 @@
 						<a href="scrollbaroperations.html" class="tsd-kind-icon">Scrollbar<wbr>Operations</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-is-external">
-						<a href="../globals.html#scrollbarlike" class="tsd-kind-icon">Scrollbar<wbr>Like</a>
+						<a href="../globals.html#scrollbar" class="tsd-kind-icon">Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-function tsd-is-external">
 						<a href="../globals.html#createdefaultscrollbarimage" class="tsd-kind-icon">create<wbr>Default<wbr>Scrollbar<wbr>Image</a>

--- a/docs/apiref/interfaces/ninepatchverticalscrollbarparameterobject.html
+++ b/docs/apiref/interfaces/ninepatchverticalscrollbarparameterobject.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<title>DefaultVerticalScrollbarParameterObject | @xnv/akashic-scrollable</title>
+	<title>NinePatchVerticalScrollbarParameterObject | @xnv/akashic-scrollable</title>
 	<meta name="description" content="">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="stylesheet" href="../assets/css/main.css">
@@ -56,10 +56,10 @@
 					<a href="../globals.html">Globals</a>
 				</li>
 				<li>
-					<a href="defaultverticalscrollbarparameterobject.html">DefaultVerticalScrollbarParameterObject</a>
+					<a href="ninepatchverticalscrollbarparameterobject.html">NinePatchVerticalScrollbarParameterObject</a>
 				</li>
 			</ul>
-			<h1>Interface DefaultVerticalScrollbarParameterObject</h1>
+			<h1>Interface NinePatchVerticalScrollbarParameterObject</h1>
 		</div>
 	</div>
 </header>
@@ -69,16 +69,16 @@
 			<section class="tsd-panel tsd-comment">
 				<div class="tsd-comment tsd-typography">
 					<div class="lead">
-						<p>The type of the argument of <code>new DefaultVerticalScrollbar()</code>.</p>
+						<p>The type of the argument of <code>new NinePatchVerticalScrollbar()</code>.</p>
 					</div>
-					<p><code>new DefaultVerticalScrollbar()</code> の引数の型。</p>
+					<p><code>new NinePatchVerticalScrollbar()</code> の引数の型。</p>
 				</div>
 			</section>
 			<section class="tsd-panel tsd-hierarchy">
 				<h3>Hierarchy</h3>
 				<ul class="tsd-hierarchy">
 					<li>
-						<span class="target">DefaultVerticalScrollbarParameterObject</span>
+						<span class="target">NinePatchVerticalScrollbarParameterObject</span>
 					</li>
 				</ul>
 			</section>
@@ -89,9 +89,9 @@
 						<section class="tsd-index-section tsd-is-external">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"><a href="defaultverticalscrollbarparameterobject.html#bgimage" class="tsd-kind-icon">bg<wbr>Image</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"><a href="defaultverticalscrollbarparameterobject.html#image" class="tsd-kind-icon">image</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"><a href="defaultverticalscrollbarparameterobject.html#scene" class="tsd-kind-icon">scene</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"><a href="ninepatchverticalscrollbarparameterobject.html#bgimage" class="tsd-kind-icon">bg<wbr>Image</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"><a href="ninepatchverticalscrollbarparameterobject.html#image" class="tsd-kind-icon">image</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"><a href="ninepatchverticalscrollbarparameterobject.html#scene" class="tsd-kind-icon">scene</a></li>
 							</ul>
 						</section>
 					</div>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">bg<wbr>Image<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Surface</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultVerticalScrollbar.ts#L10">DefaultVerticalScrollbar.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchVerticalScrollbar.ts#L10">NinePatchVerticalScrollbar.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">image<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Surface</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultVerticalScrollbar.ts#L11">DefaultVerticalScrollbar.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchVerticalScrollbar.ts#L11">NinePatchVerticalScrollbar.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">scene<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Scene</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/DefaultVerticalScrollbar.ts#L9">DefaultVerticalScrollbar.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/NinePatchVerticalScrollbar.ts#L9">NinePatchVerticalScrollbar.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,10 +142,10 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-is-external">
-						<a href="../classes/defaulthorizontalscrollbar.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar</a>
+						<a href="../classes/ninepatchhorizontalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-class tsd-is-external">
-						<a href="../classes/defaultverticalscrollbar.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar</a>
+						<a href="../classes/ninepatchverticalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-class tsd-is-external">
 						<a href="../classes/nullscrollbar.html" class="tsd-kind-icon">Null<wbr>Scrollbar</a>
@@ -160,21 +160,21 @@
 						<a href="../classes/scrolledcontentcontainer.html" class="tsd-kind-icon">Scrolled<wbr>Content<wbr>Container</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
-						<a href="defaulthorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="ninepatchhorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 					</li>
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-interface tsd-is-external">
-						<a href="defaultverticalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="ninepatchverticalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 						<ul>
 							<li class=" tsd-kind-property tsd-parent-kind-interface tsd-is-external">
-								<a href="defaultverticalscrollbarparameterobject.html#bgimage" class="tsd-kind-icon">bg<wbr>Image</a>
+								<a href="ninepatchverticalscrollbarparameterobject.html#bgimage" class="tsd-kind-icon">bg<wbr>Image</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-interface tsd-is-external">
-								<a href="defaultverticalscrollbarparameterobject.html#image" class="tsd-kind-icon">image</a>
+								<a href="ninepatchverticalscrollbarparameterobject.html#image" class="tsd-kind-icon">image</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-interface tsd-is-external">
-								<a href="defaultverticalscrollbarparameterobject.html#scene" class="tsd-kind-icon">scene</a>
+								<a href="ninepatchverticalscrollbarparameterobject.html#scene" class="tsd-kind-icon">scene</a>
 							</li>
 						</ul>
 					</li>
@@ -187,7 +187,7 @@
 						<a href="scrollbaroperations.html" class="tsd-kind-icon">Scrollbar<wbr>Operations</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-is-external">
-						<a href="../globals.html#scrollbarlike" class="tsd-kind-icon">Scrollbar<wbr>Like</a>
+						<a href="../globals.html#scrollbar" class="tsd-kind-icon">Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-function tsd-is-external">
 						<a href="../globals.html#createdefaultscrollbarimage" class="tsd-kind-icon">create<wbr>Default<wbr>Scrollbar<wbr>Image</a>

--- a/docs/apiref/interfaces/scrollableparameterobject.html
+++ b/docs/apiref/interfaces/scrollableparameterobject.html
@@ -194,7 +194,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides Object2DParameterObject.height</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L72">Scrollable.ts:72</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L72">Scrollable.ts:72</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -230,20 +230,20 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-external">
 					<a name="horizontal" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagOptional">Optional</span> horizontal</h3>
-					<div class="tsd-signature tsd-kind-icon">horizontal<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><a href="../globals.html#scrollbarlike" class="tsd-signature-type">ScrollbarLike</a></div>
+					<div class="tsd-signature tsd-kind-icon">horizontal<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><a href="../globals.html#scrollbar" class="tsd-signature-type">Scrollbar</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L94">Scrollable.ts:94</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L94">Scrollable.ts:94</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
 						<div class="lead">
 							<p>Enable/disable horizontal scrolling.
-								If a <code>ScrollbarLike</code> is given, it is used as the horizontal scrollbar instead of the default one.
+								If a <code>Scrollbar</code> is given, it is used as the horizontal scrollbar instead of the default one.
 							If not specified, <code>false</code> .</p>
 						</div>
 						<p>縦方向のスクロールを有効にするか。
-							<code>ScrollbarLike</code> が指定された場合、有効になり、値はデフォルトの横スクロールバーの代わりに利用される。
+							<code>Scrollbar</code> が指定された場合、有効になり、値はデフォルトの横スクロールバーの代わりに利用される。
 						省略された場合、偽。</p>
 					</div>
 				</section>
@@ -276,7 +276,7 @@
 					<div class="tsd-signature tsd-kind-icon">inset<wbr>Bars<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L116">Scrollable.ts:116</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L116">Scrollable.ts:116</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -468,7 +468,7 @@
 					<div class="tsd-signature tsd-kind-icon">touch<wbr>Scroll<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L103">Scrollable.ts:103</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L103">Scrollable.ts:103</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -505,20 +505,20 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-external">
 					<a name="vertical" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagOptional">Optional</span> vertical</h3>
-					<div class="tsd-signature tsd-kind-icon">vertical<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><a href="../globals.html#scrollbarlike" class="tsd-signature-type">ScrollbarLike</a></div>
+					<div class="tsd-signature tsd-kind-icon">vertical<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><a href="../globals.html#scrollbar" class="tsd-signature-type">Scrollbar</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L83">Scrollable.ts:83</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L83">Scrollable.ts:83</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
 						<div class="lead">
 							<p>Enable/disable vertical scrolling.
-								If a <code>ScrollbarLike</code> is given, it is used as the vertical scrollbar instead of the default one.
+								If a <code>Scrollbar</code> is given, it is used as the vertical scrollbar instead of the default one.
 							If not specified, <code>false</code>.</p>
 						</div>
 						<p>縦方向のスクロールを有効にするか。
-							<code>ScrollbarLike</code> が指定された場合、有効になり、値はデフォルトの縦スクロールバーの代わりに利用される。
+							<code>Scrollbar</code> が指定された場合、有効になり、値はデフォルトの縦スクロールバーの代わりに利用される。
 						省略された場合、偽。</p>
 					</div>
 				</section>
@@ -529,7 +529,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides Object2DParameterObject.width</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/Scrollable.ts#L63">Scrollable.ts:63</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollable.ts#L63">Scrollable.ts:63</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -596,10 +596,10 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-is-external">
-						<a href="../classes/defaulthorizontalscrollbar.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar</a>
+						<a href="../classes/ninepatchhorizontalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-class tsd-is-external">
-						<a href="../classes/defaultverticalscrollbar.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar</a>
+						<a href="../classes/ninepatchverticalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-class tsd-is-external">
 						<a href="../classes/nullscrollbar.html" class="tsd-kind-icon">Null<wbr>Scrollbar</a>
@@ -614,10 +614,10 @@
 						<a href="../classes/scrolledcontentcontainer.html" class="tsd-kind-icon">Scrolled<wbr>Content<wbr>Container</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
-						<a href="defaulthorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="ninepatchhorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
-						<a href="defaultverticalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="ninepatchverticalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 					</li>
 				</ul>
 				<ul class="current">
@@ -698,7 +698,7 @@
 						<a href="scrollbaroperations.html" class="tsd-kind-icon">Scrollbar<wbr>Operations</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-is-external">
-						<a href="../globals.html#scrollbarlike" class="tsd-kind-icon">Scrollbar<wbr>Like</a>
+						<a href="../globals.html#scrollbar" class="tsd-kind-icon">Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-function tsd-is-external">
 						<a href="../globals.html#createdefaultscrollbarimage" class="tsd-kind-icon">create<wbr>Default<wbr>Scrollbar<wbr>Image</a>

--- a/docs/apiref/interfaces/scrollbaroperations.html
+++ b/docs/apiref/interfaces/scrollbaroperations.html
@@ -85,8 +85,8 @@
 			<section class="tsd-panel">
 				<h3>Implemented by</h3>
 				<ul class="tsd-hierarchy">
-					<li><a href="../classes/defaulthorizontalscrollbar.html" class="tsd-signature-type">DefaultHorizontalScrollbar</a></li>
-					<li><a href="../classes/defaultverticalscrollbar.html" class="tsd-signature-type">DefaultVerticalScrollbar</a></li>
+					<li><a href="../classes/ninepatchhorizontalscrollbar.html" class="tsd-signature-type">NinePatchHorizontalScrollbar</a></li>
+					<li><a href="../classes/ninepatchverticalscrollbar.html" class="tsd-signature-type">NinePatchVerticalScrollbar</a></li>
 					<li><a href="../classes/nullscrollbar.html" class="tsd-signature-type">NullScrollbar</a></li>
 				</ul>
 			</section>
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">on<wbr>Change<wbr>Bar<wbr>Position<wbr>Rate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Trigger</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/ScrollbarLike.ts#L14">ScrollbarLike.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollbar.ts#L14">Scrollbar.ts:14</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -142,7 +142,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/4f6e692/src/ScrollbarLike.ts#L26">ScrollbarLike.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/xnv/akashic-scrollable/blob/8141b2d/src/Scrollbar.ts#L26">Scrollbar.ts:26</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -191,10 +191,10 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-is-external">
-						<a href="../classes/defaulthorizontalscrollbar.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar</a>
+						<a href="../classes/ninepatchhorizontalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-class tsd-is-external">
-						<a href="../classes/defaultverticalscrollbar.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar</a>
+						<a href="../classes/ninepatchverticalscrollbar.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-class tsd-is-external">
 						<a href="../classes/nullscrollbar.html" class="tsd-kind-icon">Null<wbr>Scrollbar</a>
@@ -209,10 +209,10 @@
 						<a href="../classes/scrolledcontentcontainer.html" class="tsd-kind-icon">Scrolled<wbr>Content<wbr>Container</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
-						<a href="defaulthorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="ninepatchhorizontalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Horizontal<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
-						<a href="defaultverticalscrollbarparameterobject.html" class="tsd-kind-icon">Default<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
+						<a href="ninepatchverticalscrollbarparameterobject.html" class="tsd-kind-icon">Nine<wbr>Patch<wbr>Vertical<wbr>Scrollbar<wbr>Parameter<wbr>Object</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-is-external">
 						<a href="scrollableparameterobject.html" class="tsd-kind-icon">Scrollable<wbr>Parameter<wbr>Object</a>
@@ -233,7 +233,7 @@
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-type-alias tsd-is-external">
-						<a href="../globals.html#scrollbarlike" class="tsd-kind-icon">Scrollbar<wbr>Like</a>
+						<a href="../globals.html#scrollbar" class="tsd-kind-icon">Scrollbar</a>
 					</li>
 					<li class=" tsd-kind-function tsd-is-external">
 						<a href="../globals.html#createdefaultscrollbarimage" class="tsd-kind-icon">create<wbr>Default<wbr>Scrollbar<wbr>Image</a>

--- a/src/NinePatchHorizontalScrollbar.ts
+++ b/src/NinePatchHorizontalScrollbar.ts
@@ -1,24 +1,25 @@
-import { ScrollbarOperations } from "./ScrollbarLike";
+import { ScrollbarOperations } from "./Scrollbar";
 
 /**
- * The type of the argument of `new DefaultVerticalScrollbar()`.
+ * The type of the argument of `new NinePatchHorizontalScrollbar()`.
  *
- * `new DefaultVerticalScrollbar()` の引数の型。
+ * `new NinePatchHorizontalScrollbar()` の引数の型。
  */
-export interface DefaultVerticalScrollbarParameterObject {
+export interface NinePatchHorizontalScrollbarParameterObject {
 	scene: g.Scene;
 	bgImage?: g.Surface;
 	image: g.Surface;
 }
 
+
 /**
- * The default vertical scrollbar entity.
- * Takes two images (as background and bar itself), use them in nine-patched style.
+ * The ninepatch image scrollbar entity.
+ * Takes two images as ninepatch images for the background and the bar itself.
  *
- * デフォルトの縦スクロールバー。
+ * 9パッチ画像の横スクロールバー。
  * 二つの画像(背景用・バー用)をとり、9パッチで拡大して利用する。
  */
-export class DefaultVerticalScrollbar extends g.Pane implements ScrollbarOperations {
+export class NinePatchHorizontalScrollbar extends g.Pane implements ScrollbarOperations {
 	onChangeBarPositionRate: g.Trigger<number>;
 	private _bar: g.Pane;
 	private _barImage: g.Surface;
@@ -26,22 +27,22 @@ export class DefaultVerticalScrollbar extends g.Pane implements ScrollbarOperati
 	private _deltaOrigin: number;
 	private _delta: number;
 
-	constructor(param: DefaultVerticalScrollbarParameterObject) {
+	constructor(param: NinePatchHorizontalScrollbarParameterObject) {
 		super({
 			scene: param.scene,
-			width: param.bgImage ? param.bgImage.width : param.image.width,
-			height: 0,
+			width: 0,
+			height: param.bgImage ? param.bgImage.height : param.image.height,
 			backgroundImage: param.bgImage,
-			backgroundEffector: param.bgImage && new g.NinePatchSurfaceEffector(param.scene.game, Math.floor(param.bgImage.width / 2))
+			backgroundEffector: param.bgImage && new g.NinePatchSurfaceEffector(param.scene.game, Math.floor(param.bgImage.height / 2))
 		});
 		this.onChangeBarPositionRate = new g.Trigger<number>();
 		this._bar = new g.Pane({
 			scene: param.scene,
 			parent: this,
-			width: param.bgImage ? param.bgImage.width : param.image.width,
-			height: 0,
+			width: 0,
+			height: param.bgImage ? param.bgImage.height : param.image.height,
 			backgroundImage: param.image,
-			backgroundEffector: new g.NinePatchSurfaceEffector(param.scene.game, Math.floor(param.image.width / 2)),
+			backgroundEffector: new g.NinePatchSurfaceEffector(param.scene.game, Math.floor(param.image.height / 2)),
 			touchable: true
 		});
 		this._barImage = param.image;
@@ -66,41 +67,41 @@ export class DefaultVerticalScrollbar extends g.Pane implements ScrollbarOperati
 		if (contentLength != null && this._contentLength !== contentLength) {
 			this._contentLength = contentLength;
 		}
-		if (viewLength != null && this.height !== viewLength) {
-			this.height = viewLength;
+		if (viewLength != null && this.width !== viewLength) {
+			this.width = viewLength;
 			this.invalidate();
 		}
-		let barHeight = 0;
-		if (this.height < this._contentLength)
-			barHeight = Math.floor(Math.max(this.height * this.height / this._contentLength, this._barImage.height));
-		const barPos = Math.floor(Math.max(posRate * this.height));
-		if (this._bar.height !== barHeight) {
-			this._bar.height = barHeight;
+		let barWidth = 0;
+		if (this.width < this._contentLength)
+			barWidth = Math.floor(Math.max(this.width * this.width / this._contentLength, this._barImage.width));
+		const barPos = Math.floor(Math.max(posRate * this.width));
+		if (this._bar.width !== barWidth) {
+			this._bar.width = barWidth;
 			this._bar.invalidate();
 		}
-		if (this._bar.y !== barPos) {
-			this._bar.y = barPos;
+		if (this._bar.x !== barPos) {
+			this._bar.x = barPos;
 			this._bar.modified();
 
 			// reset to be safe... unnecessary?
-			this._deltaOrigin = this._bar.y;
+			this._deltaOrigin = this._bar.x;
 			this._delta = 0;
 		}
 	}
 
 	private _handleBarPointDown(ev: g.PointDownEvent): void {
-		this._deltaOrigin = this._bar.y;
+		this._deltaOrigin = this._bar.x;
 		this._delta = 0;
 	}
 
 	private _handleBarPointMove(ev: g.PointMoveEvent): void {
-		this._delta += ev.prevDelta.y;
-		const limit = this.height - this._bar.height;
+		this._delta += ev.prevDelta.x;
+		const limit = this.width - this._bar.width;
 		const next = Math.min(Math.max(this._deltaOrigin + this._delta, 0), limit);
-		if (this._bar.y === next)
+		if (this._bar.x === next)
 			return;
-		this._bar.y = next;
+		this._bar.x = next;
 		this._bar.modified();
-		this.onChangeBarPositionRate.fire(next / this.height);
+		this.onChangeBarPositionRate.fire(next / this.width);
 	}
 }

--- a/src/NinePatchVerticalScrollbar.ts
+++ b/src/NinePatchVerticalScrollbar.ts
@@ -1,25 +1,24 @@
-import { ScrollbarOperations } from "./ScrollbarLike";
+import { ScrollbarOperations } from "./Scrollbar";
 
 /**
- * The type of the argument of `new DefaultHorizontalScrollbar()`.
+ * The type of the argument of `new NinePatchVerticalScrollbar()`.
  *
- * `new DefaultHorizontalScrollbar()` の引数の型。
+ * `new NinePatchVerticalScrollbar()` の引数の型。
  */
-export interface DefaultHorizontalScrollbarParameterObject {
+export interface NinePatchVerticalScrollbarParameterObject {
 	scene: g.Scene;
 	bgImage?: g.Surface;
 	image: g.Surface;
 }
 
-
 /**
- * The default horizontal scrollbar entity.
- * Takes two images (as background and bar itself), use them in nine-patched style.
+ * The ninepatch image vertical scrollbar entity.
+ * Takes two images as ninepatch images for the background and the bar itself.
  *
- * デフォルトの横スクロールバー。
+ * 9パッチ画像の縦スクロールバー。
  * 二つの画像(背景用・バー用)をとり、9パッチで拡大して利用する。
  */
-export class DefaultHorizontalScrollbar extends g.Pane implements ScrollbarOperations {
+export class NinePatchVerticalScrollbar extends g.Pane implements ScrollbarOperations {
 	onChangeBarPositionRate: g.Trigger<number>;
 	private _bar: g.Pane;
 	private _barImage: g.Surface;
@@ -27,22 +26,22 @@ export class DefaultHorizontalScrollbar extends g.Pane implements ScrollbarOpera
 	private _deltaOrigin: number;
 	private _delta: number;
 
-	constructor(param: DefaultHorizontalScrollbarParameterObject) {
+	constructor(param: NinePatchVerticalScrollbarParameterObject) {
 		super({
 			scene: param.scene,
-			width: 0,
-			height: param.bgImage ? param.bgImage.height : param.image.height,
+			width: param.bgImage ? param.bgImage.width : param.image.width,
+			height: 0,
 			backgroundImage: param.bgImage,
-			backgroundEffector: param.bgImage && new g.NinePatchSurfaceEffector(param.scene.game, Math.floor(param.bgImage.height / 2))
+			backgroundEffector: param.bgImage && new g.NinePatchSurfaceEffector(param.scene.game, Math.floor(param.bgImage.width / 2))
 		});
 		this.onChangeBarPositionRate = new g.Trigger<number>();
 		this._bar = new g.Pane({
 			scene: param.scene,
 			parent: this,
-			width: 0,
-			height: param.bgImage ? param.bgImage.height : param.image.height,
+			width: param.bgImage ? param.bgImage.width : param.image.width,
+			height: 0,
 			backgroundImage: param.image,
-			backgroundEffector: new g.NinePatchSurfaceEffector(param.scene.game, Math.floor(param.image.height / 2)),
+			backgroundEffector: new g.NinePatchSurfaceEffector(param.scene.game, Math.floor(param.image.width / 2)),
 			touchable: true
 		});
 		this._barImage = param.image;
@@ -67,41 +66,41 @@ export class DefaultHorizontalScrollbar extends g.Pane implements ScrollbarOpera
 		if (contentLength != null && this._contentLength !== contentLength) {
 			this._contentLength = contentLength;
 		}
-		if (viewLength != null && this.width !== viewLength) {
-			this.width = viewLength;
+		if (viewLength != null && this.height !== viewLength) {
+			this.height = viewLength;
 			this.invalidate();
 		}
-		let barWidth = 0;
-		if (this.width < this._contentLength)
-			barWidth = Math.floor(Math.max(this.width * this.width / this._contentLength, this._barImage.width));
-		const barPos = Math.floor(Math.max(posRate * this.width));
-		if (this._bar.width !== barWidth) {
-			this._bar.width = barWidth;
+		let barHeight = 0;
+		if (this.height < this._contentLength)
+			barHeight = Math.floor(Math.max(this.height * this.height / this._contentLength, this._barImage.height));
+		const barPos = Math.floor(Math.max(posRate * this.height));
+		if (this._bar.height !== barHeight) {
+			this._bar.height = barHeight;
 			this._bar.invalidate();
 		}
-		if (this._bar.x !== barPos) {
-			this._bar.x = barPos;
+		if (this._bar.y !== barPos) {
+			this._bar.y = barPos;
 			this._bar.modified();
 
 			// reset to be safe... unnecessary?
-			this._deltaOrigin = this._bar.x;
+			this._deltaOrigin = this._bar.y;
 			this._delta = 0;
 		}
 	}
 
 	private _handleBarPointDown(ev: g.PointDownEvent): void {
-		this._deltaOrigin = this._bar.x;
+		this._deltaOrigin = this._bar.y;
 		this._delta = 0;
 	}
 
 	private _handleBarPointMove(ev: g.PointMoveEvent): void {
-		this._delta += ev.prevDelta.x;
-		const limit = this.width - this._bar.width;
+		this._delta += ev.prevDelta.y;
+		const limit = this.height - this._bar.height;
 		const next = Math.min(Math.max(this._deltaOrigin + this._delta, 0), limit);
-		if (this._bar.x === next)
+		if (this._bar.y === next)
 			return;
-		this._bar.x = next;
+		this._bar.y = next;
 		this._bar.modified();
-		this.onChangeBarPositionRate.fire(next / this.width);
+		this.onChangeBarPositionRate.fire(next / this.height);
 	}
 }

--- a/src/NullScrollbar.ts
+++ b/src/NullScrollbar.ts
@@ -1,4 +1,4 @@
-import { ScrollbarOperations } from "./ScrollbarLike";
+import { ScrollbarOperations } from "./Scrollbar";
 
 export class NullScrollbar extends g.E implements ScrollbarOperations {
 	onChangeBarPositionRate: g.Trigger<number>;  // never be fired.

--- a/src/Scrollable.ts
+++ b/src/Scrollable.ts
@@ -1,8 +1,8 @@
 import { createDefaultScrollbarImage } from "./createDefaultScrollbarImage";
-import { ScrollbarLike } from "./ScrollbarLike";
+import { Scrollbar } from "./Scrollbar";
 import { NullScrollbar } from "./NullScrollbar";
-import { DefaultVerticalScrollbar } from "./DefaultVerticalScrollbar";
-import { DefaultHorizontalScrollbar } from "./DefaultHorizontalScrollbar";
+import { NinePatchVerticalScrollbar } from "./NinePatchVerticalScrollbar";
+import { NinePatchHorizontalScrollbar } from "./NinePatchHorizontalScrollbar";
 
 export class ScrolledContent extends g.E {
 	onModified: g.Trigger<void>;
@@ -73,25 +73,25 @@ export interface ScrollableParameterObject extends g.EParameterObject {
 
 	/**
 	 * Enable/disable vertical scrolling.
-	 * If a `ScrollbarLike` is given, it is used as the vertical scrollbar instead of the default one.
+	 * If a `Scrollbar` is given, it is used as the vertical scrollbar instead of the default one.
 	 * If not specified, `false`.
 	 *
 	 * 縦方向のスクロールを有効にするか。
-	 * `ScrollbarLike` が指定された場合、有効になり、値はデフォルトの縦スクロールバーの代わりに利用される。
+	 * `Scrollbar` が指定された場合、有効になり、値はデフォルトの縦スクロールバーの代わりに利用される。
 	 * 省略された場合、偽。
 	 */
-	vertical?: boolean | ScrollbarLike;
+	vertical?: boolean | Scrollbar;
 
 	/**
 	 * Enable/disable horizontal scrolling.
-	 * If a `ScrollbarLike` is given, it is used as the horizontal scrollbar instead of the default one.
+	 * If a `Scrollbar` is given, it is used as the horizontal scrollbar instead of the default one.
 	 * If not specified, `false` .
 	 *
 	 * 縦方向のスクロールを有効にするか。
-	 * `ScrollbarLike` が指定された場合、有効になり、値はデフォルトの横スクロールバーの代わりに利用される。
+	 * `Scrollbar` が指定された場合、有効になり、値はデフォルトの横スクロールバーの代わりに利用される。
 	 * 省略された場合、偽。
 	 */
-	horizontal?: boolean | ScrollbarLike;
+	horizontal?: boolean | Scrollbar;
 
 	/**
 	 * Enable/disable scrolling by dragging on the entity itself.
@@ -142,8 +142,8 @@ export class Scrollable extends g.E {
 	private _extraDrawOffsetY: number;
 
 	private _contentContainer: ScrolledContentContainer;
-	private _horizontalBar: ScrollbarLike;
-	private _verticalBar: ScrollbarLike;
+	private _horizontalBar: Scrollbar;
+	private _verticalBar: Scrollbar;
 
 	private _surface: g.Surface;
 	private _renderer: g.Renderer;
@@ -263,14 +263,14 @@ export class Scrollable extends g.E {
 		}
 
 		this._verticalBar =
-			(param.vertical === true) ? new DefaultVerticalScrollbar({ scene: param.scene, bgImage: this._bgImage, image: this._barImage }) :
+			(param.vertical === true) ? new NinePatchVerticalScrollbar({ scene: param.scene, bgImage: this._bgImage, image: this._barImage }) :
 			(param.vertical) ? param.vertical :
 			new NullScrollbar({ scene: param.scene });
 		this._verticalBar.x = this._insetBars ? this.width - this._verticalBar.width : this.width;
 		this.append(this._verticalBar);
 		this._verticalBar.onChangeBarPositionRate.add(this._handleOnChangeVerticalPositionRate, this);
 		this._horizontalBar =
-			(param.horizontal === true) ? new DefaultHorizontalScrollbar({ scene: param.scene, bgImage: this._bgImage, image: this._barImage }) :
+			(param.horizontal === true) ? new NinePatchHorizontalScrollbar({ scene: param.scene, bgImage: this._bgImage, image: this._barImage }) :
 			(param.horizontal) ? param.horizontal :
 			new NullScrollbar({ scene: param.scene });
 		this._horizontalBar.y = this._insetBars ? this.height - this._horizontalBar.height : this.height;

--- a/src/Scrollbar.ts
+++ b/src/Scrollbar.ts
@@ -31,4 +31,4 @@ export interface ScrollbarOperations {
  *
  * スクロールバーの型。
  */
-export type ScrollbarLike = g.E & ScrollbarOperations;
+export type Scrollbar = g.E & ScrollbarOperations;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-export * from "./ScrollbarLike";
-export * from "./DefaultHorizontalScrollbar";
-export * from "./DefaultVerticalScrollbar";
+export * from "./Scrollbar";
+export * from "./NinePatchHorizontalScrollbar";
+export * from "./NinePatchVerticalScrollbar";
 export * from "./NullScrollbar";
 export * from "./createDefaultScrollbarImage";
 import { Scrollable, ScrollableParameterObject, ScrolledContentContainer, ScrolledContent } from "./Scrollable";


### PR DESCRIPTION
- Rename `DefaultVerticalScrollbar` to `NinePatchVerticalScrollbar` to conform documents.
- Ditto for `DefaultHorizontalScrollbar`.
- Rename `ScrollbarLike` to `Scrollbar`.
