### PR TITLE
fix: avoid crash on destroy()

### DIFF
--- a/src/NullScrollbar.ts
+++ b/src/NullScrollbar.ts
@@ -11,6 +11,7 @@ export class NullScrollbar extends g.E implements ScrollbarOperations {
 	destroy(): void {
 		this.onChangeBarPositionRate.destroy();
 		this.onChangeBarPositionRate = null;
+		super.destroy();
 	}
 
 	setBarProperties(posRate?: number | null, contentlength?: number | null, viewLength?: number | null): void {

--- a/src/Scrollable.ts
+++ b/src/Scrollable.ts
@@ -13,9 +13,13 @@ export class ScrolledContent extends g.E {
 	destroy(): void {
 		this.onModified.destroy();
 		this.onModified = null;
+		super.destroy();
 	}
 	modified(isBubbling?: boolean) {
-		this.onModified.fire();
+		// Ugh! check existence since Akashic Engine calls this method while destroy()ing...
+		if (this.onModified) {
+			this.onModified.fire();
+		}
 		return super.modified(isBubbling);
 	}
 }
@@ -36,6 +40,7 @@ export class ScrolledContentContainer extends g.E {
 	destroy(): void {
 		this.onContentModified.destroy();
 		this.onContentModified = null;
+		super.destroy();
 	}
 
 	offsetContainer(): g.E {


### PR DESCRIPTION
- Add forgotten `super.destroy()` calls.
- Workaround for that the current Akashic Engine calls `E#modified()` while it is `destroy()`ing
